### PR TITLE
PLT-1214 script to delete secrets from secrets manager

### DIFF
--- a/scripts/delete_secrets.sh
+++ b/scripts/delete_secrets.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -euo pipefail
+
+
+usage() {
+  echo "Usage: $0 [--dry-run]"
+  exit 1
+}
+
+DRY_RUN=false
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=true
+elif [[ -n "${1:-}" ]]; then
+  usage
+fi
+
+echo "Select target:"
+select PREFIX in ab2d bcda dpc; do
+  if [[ -n "$PREFIX" ]]; then
+    break
+  else
+    echo "Invalid selection. Choose 1, 2, or 3."
+  fi
+done
+
+echo "Fetching secrets with prefix '$PREFIX'..."
+
+SECRETS=$(aws secretsmanager list-secrets \
+  --query "SecretList[?contains(Name, \`${PREFIX}\`)].ARN" \
+  --output text)
+
+if [[ -z "$SECRETS" ]]; then
+  echo "No secrets found matching '$PREFIX'."
+  exit 0
+fi
+
+for SECRET_ARN in $SECRETS; do
+  if $DRY_RUN; then
+    echo "[Dry Run] Would delete: $SECRET_ARN"
+  else
+    echo "Deleting: $SECRET_ARN"
+    aws secretsmanager delete-secret --secret-id "$SECRET_ARN" --force-delete-without-recovery
+  fi
+done
+
+echo "Done."
+


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1214

## 🛠 Changes

Added a script to delete all AWS Secrets Manager secrets containing ab2d, bcda, or dpc in the name.
Includes support for a --dry-run mode to safely preview deletions.


## ℹ️ Context

We are transitioning our secret management approach to standardized SOPs using SSM Parameter Store instead of AWS Secrets Manager. As part of this transition, we are cleaning up legacy secrets that are no longer used. This script facilitates that cleanup in a safe and controlled way.

## 🧪 Validation

Tested locally using the --dry-run flag to confirm which secrets would be deleted. 
