### PR TITLE
DPC-4821 set opt-out db host to cluster when cluster

### DIFF
--- a/.github/workflows/tf-opt-out-export-cluster.yml
+++ b/.github/workflows/tf-opt-out-export-cluster.yml
@@ -1,0 +1,56 @@
+name: tf-opt-out-export-cluster
+run-name: tf-opt-out-export-cluster ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
+
+on:
+  push:
+    paths:
+      - .github/workflows/tf-opt-out-export-cluster.yml
+      - terraform/modules/bucket/**
+      - terraform/modules/key/**
+      - terraform/modules/function/**
+      - terraform/modules/queue/**
+      - terraform/modules/subnets/**
+      - terraform/modules/vpc/**
+      - terraform/services/opt-out-export-cluster/**
+  workflow_dispatch:
+    inputs:
+      apply:
+        required: false
+        type: boolean
+
+jobs:
+  check-fmt:
+    runs-on: codebuild-cdap-${{github.run_id}}-${{github.run_attempt}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - run: terraform fmt -check -diff -recursive terraform/services/opt-out-export-cluster
+
+  plan-apply:
+    needs: check-fmt
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: codebuild-cdap-${{github.run_id}}-${{github.run_attempt}}
+    defaults:
+      run:
+        working-directory: ./terraform/services/opt-out-export-cluster
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [dpc]
+        env: [test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ contains(fromJSON('["dev", "test"]'), matrix.env) && secrets.NON_PROD_ACCOUNT || secrets.PROD_ACCOUNT }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
+          aws-region: ${{ vars.AWS_REGION }}
+      - run: terraform init -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}-gf.s3.tfbackend
+      - run: terraform plan -out=tf.plan
+        env:
+          TF_VAR_app: ${{ matrix.app }}
+          TF_VAR_env: ${{ matrix.env }}
+      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        run: terraform apply -auto-approve tf.plan

--- a/.github/workflows/tf-opt-out-import-cluster.yml
+++ b/.github/workflows/tf-opt-out-import-cluster.yml
@@ -1,0 +1,56 @@
+name: tf-opt-out-import-cluster
+run-name: tf-opt-out-import-cluster ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
+
+on:
+  push:
+    paths:
+      - .github/workflows/tf-opt-out-import-cluster.yml
+      - terraform/modules/bucket/**
+      - terraform/modules/key/**
+      - terraform/modules/function/**
+      - terraform/modules/queue/**
+      - terraform/modules/subnets/**
+      - terraform/modules/vpc/**
+      - terraform/services/opt-out-import-cluster/**
+  workflow_dispatch:
+    inputs:
+      apply:
+        required: false
+        type: boolean
+
+jobs:
+  check-fmt:
+    runs-on: codebuild-cdap-${{github.run_id}}-${{github.run_attempt}}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - run: terraform fmt -check -diff -recursive terraform/services/opt-out-import-cluster
+
+  plan-apply:
+    needs: check-fmt
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: codebuild-cdap-${{github.run_id}}-${{github.run_attempt}}
+    defaults:
+      run:
+        working-directory: ./terraform/services/opt-out-import-cluster
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [dpc]
+        env: [test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./actions/setup-tfenv-terraform
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ contains(fromJSON('["dev", "test"]'), matrix.env) && secrets.NON_PROD_ACCOUNT || secrets.PROD_ACCOUNT }}:role/delegatedadmin/developer/${{ matrix.app }}-${{ matrix.env }}-github-actions
+          aws-region: ${{ vars.AWS_REGION }}
+      - run: terraform init -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}-gf.s3.tfbackend
+      - run: terraform plan -out=tf.plan
+        env:
+          TF_VAR_app: ${{ matrix.app }}
+          TF_VAR_env: ${{ matrix.env }}
+      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+        run: terraform apply -auto-approve tf.plan

--- a/terraform/services/opt-out-export-cluster/README.md
+++ b/terraform/services/opt-out-export-cluster/README.md
@@ -7,9 +7,7 @@ This service sets up the infrastructure for the opt-out-export lambda function i
 Pass in a backend file when running terraform init. See variables.tf for variables to include. Example:
 
 ```bash
-export TF_VAR_app=ab2d
-export TF_VAR_env=dev
-terraform init -backend-config=../../backends/$TF_VAR_app-$TF_VAR_env-gf.s3.tfbackend
+terraform init -backend-config=../../backends/dpc-dev-gf.s3.tfbackend
 terraform apply
 ```
 

--- a/terraform/services/opt-out-export-cluster/README.md
+++ b/terraform/services/opt-out-export-cluster/README.md
@@ -1,0 +1,18 @@
+# Terraform for opt-out-export function
+
+This service sets up the infrastructure for the opt-out-export lambda function in upper and lower environments for all teams.
+
+## Manual deploy
+
+Pass in a backend file when running terraform init. See variables.tf for variables to include. Example:
+
+```bash
+export TF_VAR_app=ab2d
+export TF_VAR_env=dev
+terraform init -backend-config=../../backends/$TF_VAR_app-$TF_VAR_env-gf.s3.tfbackend
+terraform apply
+```
+
+## Automated deploy
+
+This terraform is automatically applied on merge to main by the tf-opt-out-export-cluster.yml workflow.

--- a/terraform/services/opt-out-export-cluster/main.tf
+++ b/terraform/services/opt-out-export-cluster/main.tf
@@ -2,11 +2,6 @@ locals {
   full_name = "${var.app}-${var.env}-opt-out-export"
   bfd_env   = var.env == "prod" ? "prod" : "test"
   cron = {
-    ab2d = {
-      prod = "cron(0 1 ? * WED *)"
-      test = "cron(0 13 ? * * *)"
-      dev  = "cron(0 15 ? * * *)"
-    }
     bcda = {
       prod = "cron(0 1 ? * * *)"
       test = "cron(0 13 ? * * *)"
@@ -18,14 +13,8 @@ locals {
       dev  = "cron(0 15 ? * * *)"
     }
   }
-  ab2d_db_envs = {
-    dev  = "dev"
-    test = "east-impl"
-    prod = "east-prod"
-  }
   db_sg_name = "${var.app}-${var.env}-db"
   memory_size = {
-    ab2d = 10240
     bcda = null
     dpc  = 2048
   }
@@ -51,7 +40,6 @@ data "aws_rds_cluster" "this" {
 locals {
   #FIXME: database host parameters should be standardized
   db_hosts = sensitive({
-    ab2d = data.aws_rds_cluster.this.endpoint
     bcda = "postgres://${data.aws_rds_cluster.this.endpoint}:5432/bcda"
     dpc  = data.aws_rds_cluster.this.endpoint
   })
@@ -67,8 +55,8 @@ module "opt_out_export_function" {
   name        = local.full_name
   description = "Exports data files to a BFD bucket for opt-out"
 
-  handler = var.app == "ab2d" ? "gov.cms.ab2d.attributiondatashare.AttributionDataShareHandler" : "bootstrap"
-  runtime = var.app == "ab2d" ? "java17" : "provided.al2"
+  handler = "bootstrap"
+  runtime = "provided.al2"
 
   memory_size = local.memory_size[var.app]
 

--- a/terraform/services/opt-out-export-cluster/main.tf
+++ b/terraform/services/opt-out-export-cluster/main.tf
@@ -1,0 +1,104 @@
+locals {
+  full_name = "${var.app}-${var.env}-opt-out-export"
+  bfd_env   = var.env == "prod" ? "prod" : "test"
+  cron = {
+    ab2d = {
+      prod = "cron(0 1 ? * WED *)"
+      test = "cron(0 13 ? * * *)"
+      dev  = "cron(0 15 ? * * *)"
+    }
+    bcda = {
+      prod = "cron(0 1 ? * * *)"
+      test = "cron(0 13 ? * * *)"
+      dev  = "cron(0 15 ? * * *)"
+    }
+    dpc = {
+      prod = "cron(0 1 ? * * *)"
+      test = "cron(0 13 ? * * *)"
+      dev  = "cron(0 15 ? * * *)"
+    }
+  }
+  ab2d_db_envs = {
+    dev  = "dev"
+    test = "east-impl"
+    prod = "east-prod"
+  }
+  db_sg_name = "${var.app}-${var.env}-db"
+  memory_size = {
+    ab2d = 10240
+    bcda = null
+    dpc  = 2048
+  }
+}
+
+data "aws_ssm_parameter" "bfd_account" {
+  name = "/bfd/account-id"
+}
+
+data "aws_iam_policy_document" "assume_bucket_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    resources = [
+      "arn:aws:iam::${data.aws_ssm_parameter.bfd_account.value}:role/delegatedadmin/developer/bfd-${local.bfd_env}-eft-${var.app}-ct-bucket-role"
+    ]
+  }
+}
+
+data "aws_rds_cluster" "this" {
+  cluster_identifier = "${var.app}-${var.env}-aurora"
+}
+
+locals {
+  #FIXME: database host parameters should be standardized
+  db_hosts = sensitive({
+    ab2d = data.aws_rds_cluster.this.endpoint
+    bcda = "postgres://${data.aws_rds_cluster.this.endpoint}:5432/bcda"
+    dpc  = data.aws_rds_cluster.this.endpoint
+  })
+  opt_out_db_host = local.db_hosts[var.app]
+}
+
+module "opt_out_export_function" {
+  source = "../../modules/function"
+
+  app = var.app
+  env = var.env
+
+  name        = local.full_name
+  description = "Exports data files to a BFD bucket for opt-out"
+
+  handler = var.app == "ab2d" ? "gov.cms.ab2d.attributiondatashare.AttributionDataShareHandler" : "bootstrap"
+  runtime = var.app == "ab2d" ? "java17" : "provided.al2"
+
+  memory_size = local.memory_size[var.app]
+
+  function_role_inline_policies = {
+    assume-bucket-role = data.aws_iam_policy_document.assume_bucket_role.json
+  }
+
+  schedule_expression = local.cron[var.app][var.env]
+
+  environment_variables = {
+    ENV              = var.env
+    APP_NAME         = "${var.app}-${var.env}-opt-out-export"
+    S3_UPLOAD_BUCKET = "bfd-${var.env == "prod" ? "prod" : "test"}-eft"
+    S3_UPLOAD_PATH   = "bfdeft01/${var.app}/out"
+    DB_HOST          = local.opt_out_db_host
+  }
+}
+
+# Add a rule to the database security group to allow access from the function
+
+data "aws_security_group" "db" {
+  name = local.db_sg_name
+}
+
+resource "aws_vpc_security_group_ingress_rule" "function_access" {
+  from_port   = 5432
+  to_port     = 5432
+  ip_protocol = "tcp"
+  description = "opt-out-export function access"
+
+  security_group_id            = data.aws_security_group.db.id
+  referenced_security_group_id = module.opt_out_export_function.security_group_id
+}

--- a/terraform/services/opt-out-export-cluster/outputs.tf
+++ b/terraform/services/opt-out-export-cluster/outputs.tf
@@ -1,0 +1,7 @@
+output "lambda_role_arn" {
+  value = module.opt_out_export_function.role_arn
+}
+
+output "zip_bucket" {
+  value = module.opt_out_export_function.zip_bucket
+}

--- a/terraform/services/opt-out-export-cluster/terraform.tf
+++ b/terraform/services/opt-out-export-cluster/terraform.tf
@@ -1,0 +1,18 @@
+provider "aws" {
+  default_tags {
+    tags = {
+      application = var.app
+      business    = "oeda"
+      code        = "https://github.com/CMSgov/cdap/tree/main/terraform/services/opt-out-export"
+      component   = "opt-out-export"
+      environment = var.env
+      terraform   = true
+    }
+  }
+}
+
+terraform {
+  backend "s3" {
+    key = "opt-out-export/terraform.tfstate"
+  }
+}

--- a/terraform/services/opt-out-export-cluster/variables.tf
+++ b/terraform/services/opt-out-export-cluster/variables.tf
@@ -1,0 +1,17 @@
+variable "app" {
+  description = "The application name (ab2d, bcda, dpc)"
+  type        = string
+  validation {
+    condition     = contains(["ab2d", "bcda", "dpc"], var.app)
+    error_message = "Valid value for app is ab2d, bcda, or dpc."
+  }
+}
+
+variable "env" {
+  description = "The application environment (dev, test, prod)"
+  type        = string
+  validation {
+    condition     = contains(["dev", "test", "prod"], var.env)
+    error_message = "Valid value for env is dev, test, or prod."
+  }
+}

--- a/terraform/services/opt-out-export-cluster/variables.tf
+++ b/terraform/services/opt-out-export-cluster/variables.tf
@@ -1,9 +1,9 @@
 variable "app" {
-  description = "The application name (ab2d, bcda, dpc)"
+  description = "The application name (bcda, dpc)"
   type        = string
   validation {
-    condition     = contains(["ab2d", "bcda", "dpc"], var.app)
-    error_message = "Valid value for app is ab2d, bcda, or dpc."
+    condition     = contains(["bcda", "dpc"], var.app)
+    error_message = "Valid value for app is bcda or dpc."
   }
 }
 

--- a/terraform/services/opt-out-import-cluster/README.md
+++ b/terraform/services/opt-out-import-cluster/README.md
@@ -7,7 +7,7 @@ This service sets up the infrastructure for the opt-out-import lambda function i
 Pass in a backend file when running terraform init. See variables.tf for variables to include. Example:
 
 ```bash
-terraform init -backend-config=../../backends/ab2d-dev-gf.s3.tfbackend
+terraform init -backend-config=../../backends/dpc-dev-gf.s3.tfbackend
 terraform apply
 ```
 

--- a/terraform/services/opt-out-import-cluster/README.md
+++ b/terraform/services/opt-out-import-cluster/README.md
@@ -1,0 +1,16 @@
+# Terraform for opt-out-import function and associated infra
+
+This service sets up the infrastructure for the opt-out-import lambda function in upper and lower environments for all teams.
+
+## Manual deploy
+
+Pass in a backend file when running terraform init. See variables.tf for variables to include. Example:
+
+```bash
+terraform init -backend-config=../../backends/ab2d-dev-gf.s3.tfbackend
+terraform apply
+```
+
+## Automated deploy
+
+This terraform is automatically applied on merge to main by the tf-opt-out-import-cluster.yml workflow.

--- a/terraform/services/opt-out-import-cluster/main.tf
+++ b/terraform/services/opt-out-import-cluster/main.tf
@@ -2,10 +2,6 @@ locals {
   full_name = "${var.app}-${var.env}-opt-out-import"
   bfd_env   = var.env == "prod" ? "prod" : "test"
   db_sg_name = "${var.app}-${var.env}-db"
-  memory_size = {
-    bcda = null
-    dpc  = null
-  }
 }
 
 data "aws_ssm_parameter" "bfd_account" {
@@ -45,8 +41,6 @@ module "opt_out_import_function" {
 
   handler = "bootstrap"
   runtime = "provided.al2"
-
-  memory_size = local.memory_size[var.app]
 
   function_role_inline_policies = {
     assume-bucket-role = data.aws_iam_policy_document.assume_bucket_role.json

--- a/terraform/services/opt-out-import-cluster/main.tf
+++ b/terraform/services/opt-out-import-cluster/main.tf
@@ -1,0 +1,104 @@
+locals {
+  full_name = "${var.app}-${var.env}-opt-out-import"
+  bfd_env   = var.env == "prod" ? "prod" : "test"
+  ab2d_db_envs = {
+    dev  = "dev"
+    test = "east-impl"
+    prod = "east-prod"
+  }
+  db_sg_name = "${var.app}-${var.env}-db"
+  memory_size = {
+    ab2d = 1024
+    bcda = null
+    dpc  = null
+  }
+  handler_name = {
+    ab2d = "gov.cms.ab2d.optout.OptOutHandler"
+    bcda = "bootstrap"
+    dpc  = "bootstrap"
+  }
+}
+
+data "aws_ssm_parameter" "bfd_account" {
+  name = "/bfd/account-id"
+}
+
+data "aws_iam_policy_document" "assume_bucket_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    resources = [
+      "arn:aws:iam::${data.aws_ssm_parameter.bfd_account.value}:role/delegatedadmin/developer/bfd-${local.bfd_env}-eft-${var.app}-ct-bucket-role"
+    ]
+  }
+}
+
+data "aws_rds_cluster" "this" {
+  cluster_identifier = "${var.app}-${var.env}-aurora"
+}
+
+locals {
+  #FIXME: database host parameters should be standardized
+  db_hosts = sensitive({
+    ab2d = data.aws_rds_cluster.this.endpoint
+    bcda = "postgres://${data.aws_rds_cluster.this.endpoint}:5432/bcda"
+    dpc  = data.aws_rds_cluster.this.endpoint
+  })
+  opt_out_db_host = local.db_hosts[var.app]
+}
+
+module "opt_out_import_function" {
+  source = "../../modules/function"
+
+  app = var.app
+  env = var.env
+
+  name        = local.full_name
+  description = "Ingests the most recent beneficiary opt-out list from BFD"
+
+  handler = local.handler_name[var.app]
+  runtime = var.app == "ab2d" ? "java11" : "provided.al2"
+
+  memory_size = local.memory_size[var.app]
+
+  function_role_inline_policies = {
+    assume-bucket-role = data.aws_iam_policy_document.assume_bucket_role.json
+  }
+
+  environment_variables = {
+    ENV      = var.env
+    APP_NAME = "${var.app}-${var.env}-opt-out-import"
+    DB_HOST  = local.opt_out_db_host
+  }
+}
+
+# Set up queue for receiving messages when a file is added to the bucket
+
+data "aws_ssm_parameter" "bfd_sns_topic_arn" {
+  name = "/opt-out-import/${var.app}/${var.env}/bfd-sns-topic-arn"
+}
+
+module "opt_out_import_queue" {
+  source = "../../modules/queue"
+
+  name = local.full_name
+
+  function_name = module.opt_out_import_function.name
+  sns_topic_arn = data.aws_ssm_parameter.bfd_sns_topic_arn.value
+}
+
+# Add a rule to the database security group to allow access from the function
+
+data "aws_security_group" "db" {
+  name = local.db_sg_name
+}
+
+resource "aws_security_group_rule" "function_access" {
+  type        = "ingress"
+  from_port   = 5432
+  to_port     = 5432
+  protocol    = "tcp"
+  description = "opt-out-import function access"
+
+  security_group_id        = data.aws_security_group.db.id
+  source_security_group_id = module.opt_out_import_function.security_group_id
+}

--- a/terraform/services/opt-out-import-cluster/main.tf
+++ b/terraform/services/opt-out-import-cluster/main.tf
@@ -1,21 +1,10 @@
 locals {
   full_name = "${var.app}-${var.env}-opt-out-import"
   bfd_env   = var.env == "prod" ? "prod" : "test"
-  ab2d_db_envs = {
-    dev  = "dev"
-    test = "east-impl"
-    prod = "east-prod"
-  }
   db_sg_name = "${var.app}-${var.env}-db"
   memory_size = {
-    ab2d = 1024
     bcda = null
     dpc  = null
-  }
-  handler_name = {
-    ab2d = "gov.cms.ab2d.optout.OptOutHandler"
-    bcda = "bootstrap"
-    dpc  = "bootstrap"
   }
 }
 
@@ -39,7 +28,6 @@ data "aws_rds_cluster" "this" {
 locals {
   #FIXME: database host parameters should be standardized
   db_hosts = sensitive({
-    ab2d = data.aws_rds_cluster.this.endpoint
     bcda = "postgres://${data.aws_rds_cluster.this.endpoint}:5432/bcda"
     dpc  = data.aws_rds_cluster.this.endpoint
   })
@@ -55,8 +43,8 @@ module "opt_out_import_function" {
   name        = local.full_name
   description = "Ingests the most recent beneficiary opt-out list from BFD"
 
-  handler = local.handler_name[var.app]
-  runtime = var.app == "ab2d" ? "java11" : "provided.al2"
+  handler = "bootstrap"
+  runtime = "provided.al2"
 
   memory_size = local.memory_size[var.app]
 

--- a/terraform/services/opt-out-import-cluster/main.tf
+++ b/terraform/services/opt-out-import-cluster/main.tf
@@ -1,6 +1,6 @@
 locals {
-  full_name = "${var.app}-${var.env}-opt-out-import"
-  bfd_env   = var.env == "prod" ? "prod" : "test"
+  full_name  = "${var.app}-${var.env}-opt-out-import"
+  bfd_env    = var.env == "prod" ? "prod" : "test"
   db_sg_name = "${var.app}-${var.env}-db"
 }
 

--- a/terraform/services/opt-out-import-cluster/outputs.tf
+++ b/terraform/services/opt-out-import-cluster/outputs.tf
@@ -1,0 +1,11 @@
+output "function_role_arn" {
+  value = module.opt_out_import_function.role_arn
+}
+
+output "sqs_queue_arn" {
+  value = module.opt_out_import_queue.arn
+}
+
+output "zip_bucket" {
+  value = module.opt_out_import_function.zip_bucket
+}

--- a/terraform/services/opt-out-import-cluster/terraform.tf
+++ b/terraform/services/opt-out-import-cluster/terraform.tf
@@ -1,0 +1,18 @@
+provider "aws" {
+  default_tags {
+    tags = {
+      application = var.app
+      business    = "oeda"
+      code        = "https://github.com/CMSgov/cdap/tree/main/terraform/services/opt-out-import"
+      component   = "opt-out-import"
+      environment = var.env
+      terraform   = true
+    }
+  }
+}
+
+terraform {
+  backend "s3" {
+    key = "opt-out-import/terraform.tfstate"
+  }
+}

--- a/terraform/services/opt-out-import-cluster/variables.tf
+++ b/terraform/services/opt-out-import-cluster/variables.tf
@@ -1,0 +1,17 @@
+variable "app" {
+  description = "The application name (ab2d, bcda, dpc)"
+  type        = string
+  validation {
+    condition     = contains(["ab2d", "bcda", "dpc"], var.app)
+    error_message = "Valid value for app is ab2d, bcda, or dpc."
+  }
+}
+
+variable "env" {
+  description = "The application environment (dev, test, prod)"
+  type        = string
+  validation {
+    condition     = contains(["dev", "test", "prod"], var.env)
+    error_message = "Valid value for env is dev, test, or prod."
+  }
+}

--- a/terraform/services/opt-out-import-cluster/variables.tf
+++ b/terraform/services/opt-out-import-cluster/variables.tf
@@ -1,9 +1,9 @@
 variable "app" {
-  description = "The application name (ab2d, bcda, dpc)"
+  description = "The application name (bcda, dpc)"
   type        = string
   validation {
-    condition     = contains(["ab2d", "bcda", "dpc"], var.app)
-    error_message = "Valid value for app is ab2d, bcda, or dpc."
+    condition     = contains(["bcda", "dpc"], var.app)
+    error_message = "Valid value for app is bcda or dpc."
   }
 }
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/DPC-4821

## 🛠 Changes

- Clone of opt-out-import to opt-out-import-cluster
- Clone of opt-out-export to opt-out-export-cluster
- Clones use aws_rds_cluster instead of aws_db_instance to find endpoint for DB_HOST environment variable
- new workflows to update lambdas as they use the aurora cluster instead of the rds instance

## ℹ️ Context

We are incrementally moving our databases to aurora clusters, which require a slightly different terraform resource reference. This PR makes this change in separate modules in order to make sure that existing infrastructure is not inadvertently updated (much like the Greenfield migration).

See https://github.com/CMSgov/cdap/pull/272/files for differences beween *-cluster* and *

## 🧪 Validation

Manually ran in test environment, and testing the lambdas worked.
