### PR TITLE
[PLT-1237] Removing BCDA from GHA RDS matrix.

### DIFF
--- a/.github/workflows/tf-api-rds.yml
+++ b/.github/workflows/tf-api-rds.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app: [bcda, dpc]
+        app: [dpc]
         env: [dev, test, sandbox, prod]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tf-api-rds.yml
+++ b/.github/workflows/tf-api-rds.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         app: [dpc]
-        env: [dev, test, sandbox, prod]
+        env: [dev, sandbox, prod]
     steps:
       - uses: actions/checkout@v4
       - uses: ./actions/setup-tfenv-terraform


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1237

## 🛠 Changes

BCDA is being removed from the tf-api-rds Github actions matrix in the CDAP repo.

## ℹ️ Context

As part of the migration to Aurora in all four BCDA environments, no related resources should continue to be managed by the legacy shared RDS Terraform in order to prevent unintended consequences (such as here (https://github.com/CMSgov/cdap/actions/runs/16354685093/job/46210040071#:~:text=test.cx2o6o4o45ut.us%2D-,east,-%2D1.rds.amazonaws) where the test and dev DNS records were reverted to point back to RDS from Aurora).

## 🧪 Validation

The following plan shows that only the four DPC jobs are left in the matrix: https://github.com/CMSgov/cdap/actions/runs/16605597386
