### PR TITLE
[PLT-1250] remove ab2d-lambdas repo as it has been archived

### DIFF
--- a/terraform/modules/function/main.tf
+++ b/terraform/modules/function/main.tf
@@ -2,7 +2,7 @@ locals {
   provider_domain = "token.actions.githubusercontent.com"
   repos = {
     ab2d = [
-      "repo:CMSgov/ab2d-lambdas:*",
+      "repo:CMSgov/ab2d:*",
     ]
     bcda = [
       "repo:CMSgov/bcda-app:*",

--- a/terraform/services/github-actions-role/main.tf
+++ b/terraform/services/github-actions-role/main.tf
@@ -5,7 +5,6 @@ locals {
       "repo:CMSgov/cdap:*",
       "repo:CMSgov/ab2d-contracts:*",
       "repo:CMSgov/ab2d-events:*",
-      "repo:CMSgov/ab2d-lambdas:*",
       "repo:CMSgov/ab2d-properties:*",
       "repo:CMSgov/ab2d-website:*",
       "repo:CMSgov/ab2d:*",


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1250

## 🛠 Changes

Changed the code location of ab2d lambdas so that the github action role will have correct repo in the trust policy.

## ℹ️ Context

These changes were already made manually to fix errors described in PLT-1250, lambda github workflow with incorrect permissions.  This PR is to sync the terraform with the same repo change.

## 🧪 Validation

Tested via manual changes in non-prod.
