### PR TITLE
PLT-1236: Add overrides for security groups and subnet groups, enable IAM auth by default, disable final snapshots, and copy tags to snapshots

### DIFF
--- a/terraform/modules/aurora/README.md
+++ b/terraform/modules/aurora/README.md
@@ -116,6 +116,17 @@ resource "aws_ssm_parameter" "writer_endpoint" {
      Manually updating sections between TF_DOCS tags may be overwritten.
      See https://terraform-docs.io/user-guide/configuration/ for more information.
 -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+<!--WARNING: GENERATED CONTENT with terraform-docs, e.g.
+     'terraform-docs --config "$(git rev-parse --show-toplevel)/.terraform-docs.yml" .'
+     Manually updating sections between TF_DOCS tags may be overwritten.
+     See https://terraform-docs.io/user-guide/configuration/ for more information.
+-->
 ## Requirements
 
 No requirements.
@@ -146,8 +157,10 @@ No requirements.
 | <a name="input_kms_key_override"></a> [kms\_key\_override](#input\_kms\_key\_override) | Override to the platform-managed KMS key | `string` | `null` | no |
 | <a name="input_monitoring_interval"></a> [monitoring\_interval](#input\_monitoring\_interval) | The [monitoring\_interval](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#monitoring_interval-1) in seconds determines the time between sampling enhanced monitoring metrics for the cluster. | `number` | `15` | no |
 | <a name="input_monitoring_role_arn"></a> [monitoring\_role\_arn](#input\_monitoring\_role\_arn) | ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. | `string` | `null` | no |
+| <a name="input_security_group_override"></a> [security\_group\_override](#input\_security\_group\_override) | Override for the security group name | `string` | `null` | no |
 | <a name="input_snapshot_identifier"></a> [snapshot\_identifier](#input\_snapshot\_identifier) | When provided, cluster is provisioned using the specified cluster snapshot identifier. | `string` | `null` | no |
 | <a name="input_storage_type"></a> [storage\_type](#input\_storage\_type) | Aurora cluster [storage\_type](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster#storage_type-1) | `string` | `""` | no |
+| <a name="input_subnet_group_override"></a> [subnet\_group\_override](#input\_subnet\_group\_override) | Override for the subnet group name | `string` | `null` | no |
 | <a name="input_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#input\_vpc\_security\_group\_ids) | Additional security group ids for attachment to the database security group. | `list(string)` | `[]` | no |
 
 <!--WARNING: GENERATED CONTENT with terraform-docs, e.g.

--- a/terraform/modules/aurora/main.tf
+++ b/terraform/modules/aurora/main.tf
@@ -7,7 +7,7 @@ locals {
 
 resource "aws_db_subnet_group" "this" {
   description = "${local.service_prefix} database subnet group"
-  name        = local.service_prefix
+  name        = coalesce(var.subnet_group_override, local.service_prefix)
   subnet_ids  = keys(var.platform.private_subnets)
 }
 

--- a/terraform/modules/aurora/main.tf
+++ b/terraform/modules/aurora/main.tf
@@ -80,6 +80,7 @@ resource "aws_rds_cluster" "this" {
   deletion_protection                 = var.deletion_protection
   db_cluster_parameter_group_name     = aws_rds_cluster_parameter_group.this.name
   iam_database_authentication_enabled = true
+  copy_tags_to_snapshot               = true
   vpc_security_group_ids = flatten([
     aws_security_group.this.id,
     var.platform.security_groups.cmscloud-security-tools.id,

--- a/terraform/modules/aurora/main.tf
+++ b/terraform/modules/aurora/main.tf
@@ -76,7 +76,7 @@ resource "aws_rds_cluster" "this" {
   preferred_backup_window             = var.backup_window
   preferred_maintenance_window        = var.maintenance_window
   apply_immediately                   = false
-  skip_final_snapshot                 = var.platform.is_ephemeral_env ? true : false
+  skip_final_snapshot                 = true
   deletion_protection                 = var.deletion_protection
   db_cluster_parameter_group_name     = aws_rds_cluster_parameter_group.this.name
   iam_database_authentication_enabled = true

--- a/terraform/modules/aurora/main.tf
+++ b/terraform/modules/aurora/main.tf
@@ -13,7 +13,7 @@ resource "aws_db_subnet_group" "this" {
 
 resource "aws_security_group" "this" {
   description            = "${local.service_prefix} database security group"
-  name                   = "${local.service_prefix}-db"
+  name                   = coalesce(var.security_group_override, "${local.service_prefix}-db")
   revoke_rules_on_delete = false
   tags = {
     Name = "${local.service_prefix}-db"
@@ -61,23 +61,24 @@ resource "aws_db_parameter_group" "this" {
 }
 
 resource "aws_rds_cluster" "this" {
-  cluster_identifier              = coalesce(var.cluster_identifier, local.service_prefix)
-  engine                          = local.aurora_engine
-  engine_version                  = var.engine_version
-  master_username                 = var.username
-  master_password                 = var.password
-  snapshot_identifier             = var.snapshot_identifier
-  db_subnet_group_name            = aws_db_subnet_group.this.name
-  storage_type                    = var.storage_type
-  storage_encrypted               = true
-  kms_key_id                      = coalesce(var.kms_key_override, var.platform.kms_alias_primary.target_key_arn)
-  backup_retention_period         = var.backup_retention_period
-  preferred_backup_window         = var.backup_window
-  preferred_maintenance_window    = var.maintenance_window
-  apply_immediately               = false
-  skip_final_snapshot             = var.platform.is_ephemeral_env ? true : false
-  deletion_protection             = var.deletion_protection
-  db_cluster_parameter_group_name = aws_rds_cluster_parameter_group.this.name
+  cluster_identifier                  = coalesce(var.cluster_identifier, local.service_prefix)
+  engine                              = local.aurora_engine
+  engine_version                      = var.engine_version
+  master_username                     = var.username
+  master_password                     = var.password
+  snapshot_identifier                 = var.snapshot_identifier
+  db_subnet_group_name                = aws_db_subnet_group.this.name
+  storage_type                        = var.storage_type
+  storage_encrypted                   = true
+  kms_key_id                          = coalesce(var.kms_key_override, var.platform.kms_alias_primary.target_key_arn)
+  backup_retention_period             = var.backup_retention_period
+  preferred_backup_window             = var.backup_window
+  preferred_maintenance_window        = var.maintenance_window
+  apply_immediately                   = false
+  skip_final_snapshot                 = var.platform.is_ephemeral_env ? true : false
+  deletion_protection                 = var.deletion_protection
+  db_cluster_parameter_group_name     = aws_rds_cluster_parameter_group.this.name
+  iam_database_authentication_enabled = true
   vpc_security_group_ids = flatten([
     aws_security_group.this.id,
     var.platform.security_groups.cmscloud-security-tools.id,

--- a/terraform/modules/aurora/main.tf
+++ b/terraform/modules/aurora/main.tf
@@ -1,8 +1,9 @@
 locals {
-  service_prefix = "${var.platform.app}-${var.platform.env}"
-  major_version  = split(".", var.engine_version)[0]
-  aurora_engine  = "aurora-postgresql"
-  aurora_family  = "${local.aurora_engine}${local.major_version}"
+  service_prefix      = "${var.platform.app}-${var.platform.env}"
+  major_version       = split(".", var.engine_version)[0]
+  aurora_engine       = "aurora-postgresql"
+  aurora_family       = "${local.aurora_engine}${local.major_version}"
+  security_group_name = coalesce(var.security_group_override, "${local.service_prefix}-db")
 }
 
 resource "aws_db_subnet_group" "this" {
@@ -13,10 +14,10 @@ resource "aws_db_subnet_group" "this" {
 
 resource "aws_security_group" "this" {
   description            = "${local.service_prefix} database security group"
-  name                   = coalesce(var.security_group_override, "${local.service_prefix}-db")
+  name                   = local.security_group_name
   revoke_rules_on_delete = false
   tags = {
-    Name = "${local.service_prefix}-db"
+    Name = local.security_group_name
   }
   vpc_id = var.platform.vpc_id
 }

--- a/terraform/modules/aurora/variables.tf
+++ b/terraform/modules/aurora/variables.tf
@@ -15,7 +15,6 @@ variable "platform" {
   type        = any
 }
 
-
 variable "kms_key_override" { #TODO: Consider removing this all together.
   default     = null
   description = "Override to the platform-managed KMS key"
@@ -128,5 +127,11 @@ variable "cluster_identifier" {
 variable "aws_backup_tag" {
   default     = "4hr7_w90"
   description = "Override for a standard, CDAP-managed backup tag for AWS Backups"
+  type        = string
+}
+
+variable "subnet_group_override" {
+  default     = null
+  description = "Override for subnet group name"
   type        = string
 }

--- a/terraform/modules/aurora/variables.tf
+++ b/terraform/modules/aurora/variables.tf
@@ -132,6 +132,12 @@ variable "aws_backup_tag" {
 
 variable "subnet_group_override" {
   default     = null
-  description = "Override for subnet group name"
+  description = "Override for the subnet group name"
+  type        = string
+}
+
+variable "security_group_override" {
+  default     = null
+  description = "Override for the security group name"
   type        = string
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1236

## 🛠 Changes

- Adds variables to handle overrides on the default naming for security and subnet groups.
- Enables IAM auth by default.
- Enables copying tags from cluster instances to snapshots by default.
- Disables final snapshots.

## ℹ️ Context

As part of the DPC migration from RDS to Aurora clusters, we needed to override the naming enforced by the aurora module by default on some resources. We also have a security ask to enable IAM authentication, so this will enable that by default moving forward.

## 🧪 Validation

* dpc-test Aurora instance was deployed with this version of the module
* this is functional across ab2d `dev`, `test`, `sandbox`, and `prod`
