### PR TITLE
[PLT-1120] Create aurora_export resources.

### DIFF
--- a/terraform/services/aurora-export/data.tf
+++ b/terraform/services/aurora-export/data.tf
@@ -1,0 +1,39 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "aurora_export" {
+  statement {
+    actions = [
+      "s3:ListAllMyBuckets",
+    ]
+    resources = [
+      "*"
+    ]
+  }
+  statement {
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+    ]
+    resources = [
+      module.export_bucket.arn,
+    ]
+  }
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+    resources = [
+      "${module.export_bucket.arn}/*"
+    ]
+  }
+}
+
+data "aws_kms_alias" "aurora_export_kms_alias" {
+  name     = lower("alias/bcda-${var.env}")
+}
+
+data "aws_kms_key" "aurora_export" {
+  key_id   = data.aws_kms_alias.aurora_export_kms_alias.target_key_id
+}

--- a/terraform/services/aurora-export/main.tf
+++ b/terraform/services/aurora-export/main.tf
@@ -1,0 +1,52 @@
+locals {
+  export_bucket_name = "bcda-${var.env}-export"
+}
+
+module "export_bucket" {
+  source = "../../modules/bucket"
+  name   = local.export_bucket_name
+}
+
+resource "aws_iam_policy" "aurora_export" {
+  name   = "aurora_export"
+  policy = data.aws_iam_policy_document.aurora_export.json
+}
+
+resource "aws_iam_role_policy_attachment" "aurora_export" {
+  role       = aws_iam_role.aurora_export.name
+  policy_arn = aws_iam_policy.aurora_export.arn
+}
+
+resource "aws_iam_role" "aurora_export" {
+  name        = "aurora_export"
+  description = "Allows Aurora access to the Export S3 bucket."
+  path        = "/delegatedadmin/developer/"
+
+  permissions_boundary = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/cms-cloud-admin/developer-boundary-policy"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "export.rds.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_rds_export_task" "aurora_to_s3_export" {
+  export_task_identifier = "aurora-export-task"
+  source_arn             = "arn:aws:rds:us-east-1:${data.aws_caller_identity.current.account_id}:cluster:bcda-${var.env}"
+  s3_bucket_name         = module.export_bucket.id
+  iam_role_arn           = aws_iam_role.aurora_export.arn
+  kms_key_id             = data.aws_kms_key.aurora_export.id
+  # You can specify databases, schemas, or tables to export
+  # s3_prefix              = "exports/my_data/"
+  # export_only_databases  = ["my_database"]
+  # export_only_tables     = ["my_database.my_table"]
+}

--- a/terraform/services/aurora-export/variables.tf
+++ b/terraform/services/aurora-export/variables.tf
@@ -1,0 +1,8 @@
+variable "env" {
+  description = "The application environment (test, prod)"
+  type        = string
+  validation {
+    condition     = contains(["test", "prod"], var.env)
+    error_message = "Valid value for env is test or prod."
+  }
+}


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1120

## 🛠 Changes

Added iam role, iam policy, s3 bucket and aws_rds_export_task.

## ℹ️ Context

Adding resources for exporting data from Aurora database to S3 buckets in AWS.  This data will be consumed via QuickSight.

## 🧪 Validation

<details>

<summary>Plan on Prod:</summary>

```
Terraform will perform the following actions:

**Plan: 12 to add, 0 to change, 0 to destroy.**

  # data.aws_iam_policy_document.aurora_export will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "aurora_export" {
      + id            = (known after apply)
      + json          = (known after apply)
      + minified_json = (known after apply)

      + statement {
          + actions   = [
              + "s3:ListAllMyBuckets",
            ]
          + resources = [
              + "*",
            ]
        }
      + statement {
          + actions   = [
              + "s3:GetBucketLocation",
              + "s3:ListBucket",
            ]
          + resources = [
              + (known after apply),
            ]
        }
      + statement {
          + actions   = [
              + "s3:DeleteObject",
              + "s3:GetObject",
              + "s3:PutObject",
            ]
          + resources = [
              + (known after apply),
            ]
        }
    }

  # aws_iam_policy.aurora_export will be created
  + resource "aws_iam_policy" "aurora_export" {
      + arn              = (known after apply)
      + attachment_count = (known after apply)
      + id               = (known after apply)
      + name             = "aurora_export"
      + name_prefix      = (known after apply)
      + path             = "/"
      + policy           = (known after apply)
      + policy_id        = (known after apply)
      + tags_all         = (known after apply)
    }

  # aws_iam_role.aurora_export will be created
  + resource "aws_iam_role" "aurora_export" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "export.rds.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + description           = "Allows Aurora access to the Export S3 bucket."
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "aurora_export"
      + name_prefix           = (known after apply)
      + path                  = "/delegatedadmin/developer/"
      + permissions_boundary  = "arn:aws:iam::202533514245:policy/cms-cloud-admin/developer-boundary-policy"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy (known after apply)
    }

  # aws_iam_role_policy_attachment.aurora_export will be created
  + resource "aws_iam_role_policy_attachment" "aurora_export" {
      + id         = (known after apply)
      + policy_arn = (known after apply)
      + role       = "aurora_export"
    }

  # aws_rds_export_task.aurora_to_s3_export will be created
  + resource "aws_rds_export_task" "aurora_to_s3_export" {
      + export_task_identifier = "aurora-export-task"
      + failure_cause          = (known after apply)
      + iam_role_arn           = (known after apply)
      + id                     = (known after apply)
      + kms_key_id             = "37584589-3eb7-437a-9f20-b7fc0a951eb3"
      + percent_progress       = (known after apply)
      + region                 = "us-east-1"
      + s3_bucket_name         = (known after apply)
      + s3_prefix              = (known after apply)
      + snapshot_time          = (known after apply)
      + source_arn             = "arn:aws:rds:us-east-1:202533514245:cluster:bcda-prod"
      + source_type            = (known after apply)
      + status                 = (known after apply)
      + task_end_time          = (known after apply)
      + task_start_time        = (known after apply)
      + warning_message        = (known after apply)
    }

  # module.export_bucket.data.aws_iam_policy_document.this will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "this" {
      + id            = (known after apply)
      + json          = (known after apply)
      + minified_json = (known after apply)

      + statement {
          + actions   = [
              + "s3:*",
            ]
          + effect    = "Deny"
          + resources = [
              + (known after apply),
              + (known after apply),
            ]
          + sid       = "AllowSSLRequestsOnly"

          + condition {
              + test     = "Bool"
              + values   = [
                  + "false",
                ]
              + variable = "aws:SecureTransport"
            }

          + principals {
              + identifiers = [
                  + "*",
                ]
              + type        = "AWS"
            }
        }
    }

  # module.export_bucket.aws_s3_bucket.this will be created
  + resource "aws_s3_bucket" "this" {
      + acceleration_status         = (known after apply)
      + acl                         = (known after apply)
      + arn                         = (known after apply)
      + bucket                      = (known after apply)
      + bucket_domain_name          = (known after apply)
      + bucket_prefix               = "bcda-prod-export-"
      + bucket_region               = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = true
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + policy                      = (known after apply)
      + region                      = "us-east-1"
      + request_payer               = (known after apply)
      + tags_all                    = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + cors_rule (known after apply)

      + grant (known after apply)

      + lifecycle_rule (known after apply)

      + logging (known after apply)

      + object_lock_configuration (known after apply)

      + replication_configuration (known after apply)

      + server_side_encryption_configuration (known after apply)

      + versioning (known after apply)

      + website (known after apply)
    }

  # module.export_bucket.aws_s3_bucket_logging.this will be created
  + resource "aws_s3_bucket_logging" "this" {
      + bucket        = (known after apply)
      + id            = (known after apply)
      + region        = "us-east-1"
      + target_bucket = "bucket-access-logs-20250411172631068600000001"
      + target_prefix = (known after apply)
    }

  # module.export_bucket.aws_s3_bucket_policy.this will be created
  + resource "aws_s3_bucket_policy" "this" {
      + bucket = (known after apply)
      + id     = (known after apply)
      + policy = (known after apply)
      + region = "us-east-1"
    }

  # module.export_bucket.aws_s3_bucket_server_side_encryption_configuration.this will be created
  + resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
      + bucket = (known after apply)
      + id     = (known after apply)
      + region = "us-east-1"

      + rule {
          + bucket_key_enabled = true

          + apply_server_side_encryption_by_default {
              + kms_master_key_id = (known after apply)
              + sse_algorithm     = "aws:kms"
            }
        }
    }

  # module.export_bucket.aws_s3_bucket_versioning.this will be created
  + resource "aws_s3_bucket_versioning" "this" {
      + bucket = (known after apply)
      + id     = (known after apply)
      + region = "us-east-1"

      + versioning_configuration {
          + mfa_delete = (known after apply)
          + status     = "Enabled"
        }
    }

  # module.export_bucket.module.bucket_key.data.aws_iam_policy_document.this will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "aws_iam_policy_document" "this" {
      + id            = (known after apply)
      + json          = (known after apply)
      + minified_json = (known after apply)

      + statement {
          + actions   = [
              + "kms:*",
            ]
          + resources = [
              + "*",
            ]
          + sid       = "Enable IAM User Permissions"

          + principals {
              + identifiers = [
                  + "arn:aws:iam::202533514245:root",
                ]
              + type        = "AWS"
            }
        }
    }

  # module.export_bucket.module.bucket_key.aws_kms_alias.this will be created
  + resource "aws_kms_alias" "this" {
      + arn            = (known after apply)
      + id             = (known after apply)
      + name           = "alias/bcda-prod-export-bucket"
      + name_prefix    = (known after apply)
      + region         = "us-east-1"
      + target_key_arn = (known after apply)
      + target_key_id  = (known after apply)
    }

  # module.export_bucket.module.bucket_key.aws_kms_key.this will be created
  + resource "aws_kms_key" "this" {
      + arn                                = (known after apply)
      + bypass_policy_lockout_safety_check = false
      + customer_master_key_spec           = "SYMMETRIC_DEFAULT"
      + description                        = "For bcda-prod-export S3 bucket and its access logs"
      + enable_key_rotation                = true
      + id                                 = (known after apply)
      + is_enabled                         = true
      + key_id                             = (known after apply)
      + key_usage                          = "ENCRYPT_DECRYPT"
      + multi_region                       = (known after apply)
      + policy                             = (known after apply)
      + region                             = "us-east-1"
      + rotation_period_in_days            = (known after apply)
      + tags_all                           = (known after apply)
    }

  # module.export_bucket.module.bucket_key.aws_kms_key_policy.this will be created
  + resource "aws_kms_key_policy" "this" {
      + bypass_policy_lockout_safety_check = false
      + id                                 = (known after apply)
      + key_id                             = (known after apply)
      + policy                             = (known after apply)
      + region                             = "us-east-1"
    }

Plan: 12 to add, 0 to change, 0 to destroy.


```
