### PR TITLE
[PLT-1208] Ignore SG description change in Aurora module

### DIFF
--- a/terraform/modules/aurora/main.tf
+++ b/terraform/modules/aurora/main.tf
@@ -20,6 +20,12 @@ resource "aws_security_group" "this" {
     Name = local.security_group_name
   }
   vpc_id = var.platform.vpc_id
+
+  lifecycle {
+    ignore_changes = [
+      description
+    ]
+  }
 }
 
 resource "aws_vpc_security_group_egress_rule" "this" {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1208

## 🛠 Changes

This PR adds a lifecycle block to the aws_security_group.this resource in the Aurora module that will cause Terraform to ignore changes to the security group description.

## ℹ️ Context

This change is required to prevent Terraform from destroying and then recreating a security group where the description does not match the one generated by the Aurora module since security group metadata (such as name and description) cannot be edited.

A security_group_name override has already been implemented to work around importing a security group with a different name, but rather than adding another workaround for the description is seems more straightforward to just ignore the description on imported resources.

## 🧪 Validation

This change was validated on the BCDA test environment by importing the security group with `terraform import module.db.aws_security_group.this sg-xxxxxxxxxxxxxxxxx` and then running a `terraform plan` to verify that the security group will no longer be destroyed and then recreated:

```
# module.db.aws_security_group.this will be updated in-place
  ~ resource "aws_security_group" "this" {
        id                     = "sg-xxxxxxxxxxxxxxxxx"
        name                   = "bcda-test-db"
      + revoke_rules_on_delete = false
      ~ tags                   = {
            "Name"           = "bcda-test-db"
          - "application"    = "bcda" -> null
          - "business"       = "oeda" -> null
          - "environment"    = "test" -> null
          - "parent_env"     = "test" -> null
          - "service"        = "api-rds" -> null
          - "terraform"      = "true" -> null
          - "tf_root_module" = "https://github.com/CMSgov/cdap/tree/main/terraform/services/api-rds" -> null
        }
      ~ tags_all               = {
          - "application"    = "bcda" -> null
          - "business"       = "oeda" -> null
          - "environment"    = "test" -> null
          - "parent_env"     = "test" -> null
          - "service"        = "api-rds" -> null
          - "terraform"      = "true" -> null
          - "tf_root_module" = "https://github.com/CMSgov/cdap/tree/main/terraform/services/api-rds" -> null
            # (1 unchanged element hidden)
        }
        # (7 unchanged attributes hidden)
    }
```