### PR TITLE
PLT-1269 Add BCDA config kms key to more services

### DIFF
--- a/terraform/services/admin-aco-deny/main.tf
+++ b/terraform/services/admin-aco-deny/main.tf
@@ -2,6 +2,12 @@ locals {
   full_name   = "${var.app}-${var.env}-admin-aco-deny"
   db_sg_name  = "bcda-${var.env}-db"
   memory_size = 256
+  extra_kms_key_arns = var.app == "bcda" ? [data.aws_kms_alias.bcda_app_config_kms_key[0].target_key_arn] : []
+}
+
+data "aws_kms_alias" "bcda_app_config_kms_key" {
+  count = var.app == "bcda" ? 1 : 0
+  name  = "alias/bcda-${var.env}-app-config-kms"
 }
 
 module "admin_aco_deny_function" {
@@ -22,6 +28,7 @@ module "admin_aco_deny_function" {
     ENV      = var.env
     APP_NAME = "${var.app}-${var.env}-admin-aco-deny"
   }
+  extra_kms_key_arns = local.extra_kms_key_arns
 }
 
 # Add a rule to the database security group to allow access from the function

--- a/terraform/services/admin-aco-deny/main.tf
+++ b/terraform/services/admin-aco-deny/main.tf
@@ -1,8 +1,8 @@
 locals {
-  full_name          = "${var.app}-${var.env}-admin-aco-deny"
-  db_sg_name         = "bcda-${var.env}-db"
-  memory_size        = 256
-  
+  full_name   = "${var.app}-${var.env}-admin-aco-deny"
+  db_sg_name  = "bcda-${var.env}-db"
+  memory_size = 256
+
   extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }
 

--- a/terraform/services/admin-aco-deny/main.tf
+++ b/terraform/services/admin-aco-deny/main.tf
@@ -2,12 +2,11 @@ locals {
   full_name          = "${var.app}-${var.env}-admin-aco-deny"
   db_sg_name         = "bcda-${var.env}-db"
   memory_size        = 256
-  extra_kms_key_arns = var.app == "bcda" ? [data.aws_kms_alias.bcda_app_config_kms_key[0].target_key_arn] : []
+  extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }
 
 data "aws_kms_alias" "bcda_app_config_kms_key" {
-  count = var.app == "bcda" ? 1 : 0
-  name  = "alias/bcda-${var.env}-app-config-kms"
+  name = "alias/bcda-${var.env}-app-config-kms"
 }
 
 module "admin_aco_deny_function" {

--- a/terraform/services/admin-aco-deny/main.tf
+++ b/terraform/services/admin-aco-deny/main.tf
@@ -1,7 +1,7 @@
 locals {
-  full_name   = "${var.app}-${var.env}-admin-aco-deny"
-  db_sg_name  = "bcda-${var.env}-db"
-  memory_size = 256
+  full_name          = "${var.app}-${var.env}-admin-aco-deny"
+  db_sg_name         = "bcda-${var.env}-db"
+  memory_size        = 256
   extra_kms_key_arns = var.app == "bcda" ? [data.aws_kms_alias.bcda_app_config_kms_key[0].target_key_arn] : []
 }
 

--- a/terraform/services/admin-aco-deny/main.tf
+++ b/terraform/services/admin-aco-deny/main.tf
@@ -2,8 +2,6 @@ locals {
   full_name   = "${var.app}-${var.env}-admin-aco-deny"
   db_sg_name  = "bcda-${var.env}-db"
   memory_size = 256
-
-  extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }
 
 data "aws_kms_alias" "bcda_app_config_kms_key" {
@@ -28,7 +26,8 @@ module "admin_aco_deny_function" {
     ENV      = var.env
     APP_NAME = "${var.app}-${var.env}-admin-aco-deny"
   }
-  extra_kms_key_arns = local.extra_kms_key_arns
+
+  extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }
 
 # Add a rule to the database security group to allow access from the function

--- a/terraform/services/admin-aco-deny/main.tf
+++ b/terraform/services/admin-aco-deny/main.tf
@@ -2,6 +2,7 @@ locals {
   full_name          = "${var.app}-${var.env}-admin-aco-deny"
   db_sg_name         = "bcda-${var.env}-db"
   memory_size        = 256
+  
   extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }
 

--- a/terraform/services/admin-create-aco-creds/main.tf
+++ b/terraform/services/admin-create-aco-creds/main.tf
@@ -1,8 +1,8 @@
 locals {
-  full_name         = "${var.app}-${var.env}-admin-create-aco-creds"
-  db_sg_name        = "bcda-${var.env}-db"
-  memory_size       = 256
-  creds_bucket_name = "bcda-${var.env}-aco-creds-*"
+  full_name          = "${var.app}-${var.env}-admin-create-aco-creds"
+  db_sg_name         = "bcda-${var.env}-db"
+  memory_size        = 256
+  creds_bucket_name  = "bcda-${var.env}-aco-creds-*"
   extra_kms_key_arns = var.app == "bcda" ? [data.aws_kms_alias.bcda_app_config_kms_key[0].target_key_arn] : []
 }
 

--- a/terraform/services/admin-create-aco-creds/main.tf
+++ b/terraform/services/admin-create-aco-creds/main.tf
@@ -3,8 +3,6 @@ locals {
   db_sg_name        = "bcda-${var.env}-db"
   memory_size       = 256
   creds_bucket_name = "bcda-${var.env}-aco-creds-*"
-
-  extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }
 
 data "aws_kms_alias" "bcda_app_config_kms_key" {
@@ -50,7 +48,8 @@ module "admin_create_aco_creds_function" {
     ENV      = var.env
     APP_NAME = "${var.app}-${var.env}-admin-create-aco-creds"
   }
-  extra_kms_key_arns = local.extra_kms_key_arns
+
+  extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }
 
 # Add a rule to the database security group to allow access from the function

--- a/terraform/services/admin-create-aco-creds/main.tf
+++ b/terraform/services/admin-create-aco-creds/main.tf
@@ -3,6 +3,12 @@ locals {
   db_sg_name        = "bcda-${var.env}-db"
   memory_size       = 256
   creds_bucket_name = "bcda-${var.env}-aco-creds-*"
+  extra_kms_key_arns = var.app == "bcda" ? [data.aws_kms_alias.bcda_app_config_kms_key[0].target_key_arn] : []
+}
+
+data "aws_kms_alias" "bcda_app_config_kms_key" {
+  count = var.app == "bcda" ? 1 : 0
+  name  = "alias/bcda-${var.env}-app-config-kms"
 }
 
 data "aws_caller_identity" "current" {}
@@ -44,6 +50,7 @@ module "admin_create_aco_creds_function" {
     ENV      = var.env
     APP_NAME = "${var.app}-${var.env}-admin-create-aco-creds"
   }
+  extra_kms_key_arns = local.extra_kms_key_arns
 }
 
 # Add a rule to the database security group to allow access from the function

--- a/terraform/services/admin-create-aco-creds/main.tf
+++ b/terraform/services/admin-create-aco-creds/main.tf
@@ -3,12 +3,11 @@ locals {
   db_sg_name         = "bcda-${var.env}-db"
   memory_size        = 256
   creds_bucket_name  = "bcda-${var.env}-aco-creds-*"
-  extra_kms_key_arns = var.app == "bcda" ? [data.aws_kms_alias.bcda_app_config_kms_key[0].target_key_arn] : []
+  extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }
 
 data "aws_kms_alias" "bcda_app_config_kms_key" {
-  count = var.app == "bcda" ? 1 : 0
-  name  = "alias/bcda-${var.env}-app-config-kms"
+  name = "alias/bcda-${var.env}-app-config-kms"
 }
 
 data "aws_caller_identity" "current" {}

--- a/terraform/services/admin-create-aco-creds/main.tf
+++ b/terraform/services/admin-create-aco-creds/main.tf
@@ -1,9 +1,9 @@
 locals {
-  full_name          = "${var.app}-${var.env}-admin-create-aco-creds"
-  db_sg_name         = "bcda-${var.env}-db"
-  memory_size        = 256
-  creds_bucket_name  = "bcda-${var.env}-aco-creds-*"
-  
+  full_name         = "${var.app}-${var.env}-admin-create-aco-creds"
+  db_sg_name        = "bcda-${var.env}-db"
+  memory_size       = 256
+  creds_bucket_name = "bcda-${var.env}-aco-creds-*"
+
   extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }
 

--- a/terraform/services/admin-create-aco-creds/main.tf
+++ b/terraform/services/admin-create-aco-creds/main.tf
@@ -3,6 +3,7 @@ locals {
   db_sg_name         = "bcda-${var.env}-db"
   memory_size        = 256
   creds_bucket_name  = "bcda-${var.env}-aco-creds-*"
+  
   extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }
 

--- a/terraform/services/admin-create-aco/main.tf
+++ b/terraform/services/admin-create-aco/main.tf
@@ -2,12 +2,11 @@ locals {
   full_name          = "${var.app}-${var.env}-admin-create-aco"
   db_sg_name         = "bcda-${var.env}-db"
   memory_size        = 256
-  extra_kms_key_arns = var.app == "bcda" ? [data.aws_kms_alias.bcda_app_config_kms_key[0].target_key_arn] : []
+  extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }
 
 data "aws_kms_alias" "bcda_app_config_kms_key" {
-  count = var.app == "bcda" ? 1 : 0
-  name  = "alias/bcda-${var.env}-app-config-kms"
+  name = "alias/bcda-${var.env}-app-config-kms"
 }
 
 module "admin_create_aco_function" {

--- a/terraform/services/admin-create-aco/main.tf
+++ b/terraform/services/admin-create-aco/main.tf
@@ -2,6 +2,7 @@ locals {
   full_name          = "${var.app}-${var.env}-admin-create-aco"
   db_sg_name         = "bcda-${var.env}-db"
   memory_size        = 256
+  
   extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }
 

--- a/terraform/services/admin-create-aco/main.tf
+++ b/terraform/services/admin-create-aco/main.tf
@@ -26,7 +26,7 @@ module "admin_create_aco_function" {
     ENV      = var.env
     APP_NAME = "${var.app}-${var.env}-admin-create-aco"
   }
-  
+
   extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }
 

--- a/terraform/services/admin-create-aco/main.tf
+++ b/terraform/services/admin-create-aco/main.tf
@@ -2,8 +2,6 @@ locals {
   full_name   = "${var.app}-${var.env}-admin-create-aco"
   db_sg_name  = "bcda-${var.env}-db"
   memory_size = 256
-
-  extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }
 
 data "aws_kms_alias" "bcda_app_config_kms_key" {
@@ -28,7 +26,8 @@ module "admin_create_aco_function" {
     ENV      = var.env
     APP_NAME = "${var.app}-${var.env}-admin-create-aco"
   }
-  extra_kms_key_arns = local.extra_kms_key_arns
+  
+  extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }
 
 # Add a rule to the database security group to allow access from the function

--- a/terraform/services/admin-create-aco/main.tf
+++ b/terraform/services/admin-create-aco/main.tf
@@ -1,7 +1,13 @@
 locals {
-  full_name   = "${var.app}-${var.env}-admin-create-aco"
-  db_sg_name  = "bcda-${var.env}-db"
-  memory_size = 256
+  full_name          = "${var.app}-${var.env}-admin-create-aco"
+  db_sg_name         = "bcda-${var.env}-db"
+  memory_size        = 256
+  extra_kms_key_arns = var.app == "bcda" ? [data.aws_kms_alias.bcda_app_config_kms_key[0].target_key_arn] : []
+}
+
+data "aws_kms_alias" "bcda_app_config_kms_key" {
+  count = var.app == "bcda" ? 1 : 0
+  name  = "alias/bcda-${var.env}-app-config-kms"
 }
 
 module "admin_create_aco_function" {
@@ -22,6 +28,7 @@ module "admin_create_aco_function" {
     ENV      = var.env
     APP_NAME = "${var.app}-${var.env}-admin-create-aco"
   }
+  extra_kms_key_arns = local.extra_kms_key_arns
 }
 
 # Add a rule to the database security group to allow access from the function

--- a/terraform/services/admin-create-aco/main.tf
+++ b/terraform/services/admin-create-aco/main.tf
@@ -1,8 +1,8 @@
 locals {
-  full_name          = "${var.app}-${var.env}-admin-create-aco"
-  db_sg_name         = "bcda-${var.env}-db"
-  memory_size        = 256
-  
+  full_name   = "${var.app}-${var.env}-admin-create-aco"
+  db_sg_name  = "bcda-${var.env}-db"
+  memory_size = 256
+
   extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }
 

--- a/terraform/services/admin-create-group/main.tf
+++ b/terraform/services/admin-create-group/main.tf
@@ -2,6 +2,12 @@ locals {
   full_name   = "${var.app}-${var.env}-admin-create-group"
   db_sg_name  = "bcda-${var.env}-db"
   memory_size = 2048
+  extra_kms_key_arns = var.app == "bcda" ? [data.aws_kms_alias.bcda_app_config_kms_key[0].target_key_arn] : []
+}
+
+data "aws_kms_alias" "bcda_app_config_kms_key" {
+  count = var.app == "bcda" ? 1 : 0
+  name  = "alias/bcda-${var.env}-app-config-kms"
 }
 
 module "admin_create_group_function" {
@@ -22,6 +28,7 @@ module "admin_create_group_function" {
     ENV      = var.env
     APP_NAME = "${var.app}-${var.env}-admin-create-group"
   }
+  extra_kms_key_arns = local.extra_kms_key_arns
 }
 
 # Add a rule to the database security group to allow access from the function

--- a/terraform/services/admin-create-group/main.tf
+++ b/terraform/services/admin-create-group/main.tf
@@ -1,8 +1,8 @@
 locals {
-  full_name          = "${var.app}-${var.env}-admin-create-group"
-  db_sg_name         = "bcda-${var.env}-db"
-  memory_size        = 2048
-  
+  full_name   = "${var.app}-${var.env}-admin-create-group"
+  db_sg_name  = "bcda-${var.env}-db"
+  memory_size = 2048
+
   extra_kms_key_arns = data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn
 }
 

--- a/terraform/services/admin-create-group/main.tf
+++ b/terraform/services/admin-create-group/main.tf
@@ -1,7 +1,7 @@
 locals {
-  full_name   = "${var.app}-${var.env}-admin-create-group"
-  db_sg_name  = "bcda-${var.env}-db"
-  memory_size = 2048
+  full_name          = "${var.app}-${var.env}-admin-create-group"
+  db_sg_name         = "bcda-${var.env}-db"
+  memory_size        = 2048
   extra_kms_key_arns = var.app == "bcda" ? [data.aws_kms_alias.bcda_app_config_kms_key[0].target_key_arn] : []
 }
 

--- a/terraform/services/admin-create-group/main.tf
+++ b/terraform/services/admin-create-group/main.tf
@@ -2,6 +2,7 @@ locals {
   full_name          = "${var.app}-${var.env}-admin-create-group"
   db_sg_name         = "bcda-${var.env}-db"
   memory_size        = 2048
+  
   extra_kms_key_arns = data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn
 }
 

--- a/terraform/services/admin-create-group/main.tf
+++ b/terraform/services/admin-create-group/main.tf
@@ -2,12 +2,11 @@ locals {
   full_name          = "${var.app}-${var.env}-admin-create-group"
   db_sg_name         = "bcda-${var.env}-db"
   memory_size        = 2048
-  extra_kms_key_arns = var.app == "bcda" ? [data.aws_kms_alias.bcda_app_config_kms_key[0].target_key_arn] : []
+  extra_kms_key_arns = data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn
 }
 
 data "aws_kms_alias" "bcda_app_config_kms_key" {
-  count = var.app == "bcda" ? 1 : 0
-  name  = "alias/bcda-${var.env}-app-config-kms"
+  name = "alias/bcda-${var.env}-app-config-kms"
 }
 
 module "admin_create_group_function" {

--- a/terraform/services/admin-create-group/main.tf
+++ b/terraform/services/admin-create-group/main.tf
@@ -3,7 +3,7 @@ locals {
   db_sg_name  = "bcda-${var.env}-db"
   memory_size = 2048
 
-  extra_kms_key_arns = data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn
+  extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }
 
 data "aws_kms_alias" "bcda_app_config_kms_key" {

--- a/terraform/services/admin-create-group/main.tf
+++ b/terraform/services/admin-create-group/main.tf
@@ -2,8 +2,6 @@ locals {
   full_name   = "${var.app}-${var.env}-admin-create-group"
   db_sg_name  = "bcda-${var.env}-db"
   memory_size = 2048
-
-  extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }
 
 data "aws_kms_alias" "bcda_app_config_kms_key" {
@@ -28,7 +26,8 @@ module "admin_create_group_function" {
     ENV      = var.env
     APP_NAME = "${var.app}-${var.env}-admin-create-group"
   }
-  extra_kms_key_arns = local.extra_kms_key_arns
+
+  extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }
 
 # Add a rule to the database security group to allow access from the function

--- a/terraform/services/api-waf-sync/main.tf
+++ b/terraform/services/api-waf-sync/main.tf
@@ -1,12 +1,11 @@
 locals {
   full_name          = "${var.app}-${var.env}-api-waf-sync"
   db_sg_name         = "${var.app}-${var.env}-db"
-  extra_kms_key_arns = var.app == "bcda" ? [data.aws_kms_alias.bcda_app_config_kms_key[0].target_key_arn] : []
+  extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key[0].target_key_arn]
 }
 
 data "aws_kms_alias" "bcda_app_config_kms_key" {
-  count = var.app == "bcda" ? 1 : 0
-  name  = "alias/bcda-${var.env}-app-config-kms"
+  name = "alias/bcda-${var.env}-app-config-kms"
 }
 
 module "api_waf_sync_function" {

--- a/terraform/services/api-waf-sync/main.tf
+++ b/terraform/services/api-waf-sync/main.tf
@@ -1,6 +1,12 @@
 locals {
   full_name  = "${var.app}-${var.env}-api-waf-sync"
   db_sg_name = "${var.app}-${var.env}-db"
+   extra_kms_key_arns = var.app == "bcda" ? [data.aws_kms_alias.bcda_app_config_kms_key[0].target_key_arn] : []
+}
+
+data "aws_kms_alias" "bcda_app_config_kms_key" {
+  count = var.app == "bcda" ? 1 : 0
+  name  = "alias/bcda-${var.env}-app-config-kms"
 }
 
 module "api_waf_sync_function" {
@@ -26,6 +32,7 @@ module "api_waf_sync_function" {
     APP_NAME = "${var.app}-${var.env}-api-waf-sync"
     DB_HOST  = data.aws_ssm_parameter.dpc_db_host.value
   }
+  extra_kms_key_arns = local.extra_kms_key_arns
 }
 
 # Add a rule to the database security group to allow access from the function

--- a/terraform/services/api-waf-sync/main.tf
+++ b/terraform/services/api-waf-sync/main.tf
@@ -1,8 +1,6 @@
 locals {
   full_name  = "${var.app}-${var.env}-api-waf-sync"
   db_sg_name = "${var.app}-${var.env}-db"
-
-  extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }
 
 data "aws_kms_alias" "bcda_app_config_kms_key" {
@@ -32,7 +30,8 @@ module "api_waf_sync_function" {
     APP_NAME = "${var.app}-${var.env}-api-waf-sync"
     DB_HOST  = data.aws_ssm_parameter.dpc_db_host.value
   }
-  extra_kms_key_arns = local.extra_kms_key_arns
+
+  extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }
 
 # Add a rule to the database security group to allow access from the function

--- a/terraform/services/api-waf-sync/main.tf
+++ b/terraform/services/api-waf-sync/main.tf
@@ -1,7 +1,8 @@
 locals {
   full_name          = "${var.app}-${var.env}-api-waf-sync"
   db_sg_name         = "${var.app}-${var.env}-db"
-  extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key[0].target_key_arn]
+
+  extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }
 
 data "aws_kms_alias" "bcda_app_config_kms_key" {

--- a/terraform/services/api-waf-sync/main.tf
+++ b/terraform/services/api-waf-sync/main.tf
@@ -1,7 +1,7 @@
 locals {
-  full_name  = "${var.app}-${var.env}-api-waf-sync"
-  db_sg_name = "${var.app}-${var.env}-db"
-   extra_kms_key_arns = var.app == "bcda" ? [data.aws_kms_alias.bcda_app_config_kms_key[0].target_key_arn] : []
+  full_name          = "${var.app}-${var.env}-api-waf-sync"
+  db_sg_name         = "${var.app}-${var.env}-db"
+  extra_kms_key_arns = var.app == "bcda" ? [data.aws_kms_alias.bcda_app_config_kms_key[0].target_key_arn] : []
 }
 
 data "aws_kms_alias" "bcda_app_config_kms_key" {

--- a/terraform/services/api-waf-sync/main.tf
+++ b/terraform/services/api-waf-sync/main.tf
@@ -1,6 +1,6 @@
 locals {
-  full_name          = "${var.app}-${var.env}-api-waf-sync"
-  db_sg_name         = "${var.app}-${var.env}-db"
+  full_name  = "${var.app}-${var.env}-api-waf-sync"
+  db_sg_name = "${var.app}-${var.env}-db"
 
   extra_kms_key_arns = [data.aws_kms_alias.bcda_app_config_kms_key.target_key_arn]
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1269

## 🛠 Changes

Add bcda config kms key to bcda services to read the values in param store.

## ℹ️ Context

We updated our functions to use the shared kms keys but for bcda we need to add the config kms key to more services to read values stored in param store.

## 🧪 Validation

See checks.