### PR TITLE
PLT-1282: Update bucket module to use shared KMS keys

### DIFF
--- a/terraform/modules/bucket/main.tf
+++ b/terraform/modules/bucket/main.tf
@@ -26,6 +26,10 @@ resource "aws_s3_bucket_versioning" "this" {
   }
 }
 
+data "aws_kms_alias" "kms_key" {
+  name = "alias/${var.app}-${var.env}"
+}
+
 data "aws_iam_policy_document" "this" {
   statement {
     sid = "AllowSSLRequestsOnly"
@@ -88,7 +92,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
 
   rule {
     apply_server_side_encryption_by_default {
-      kms_master_key_id = module.bucket_key.id
+      kms_master_key_id = data.aws_kms_alias.kms_key.target_key_arn
       sse_algorithm     = "aws:kms"
     }
     bucket_key_enabled = true

--- a/terraform/modules/bucket/variables.tf
+++ b/terraform/modules/bucket/variables.tf
@@ -1,3 +1,21 @@
+variable "app" {
+  description = "The application name (ab2d, bcda, dpc)"
+  type        = string
+  validation {
+    condition     = contains(["ab2d", "bcda", "dpc"], var.app)
+    error_message = "Valid value for app is ab2d, bcda, or dpc."
+  }
+}
+
+variable "env" {
+  description = "The application environment (dev, test, sandbox, prod)"
+  type        = string
+  validation {
+    condition     = contains(["dev", "test", "sandbox", "prod"], var.env)
+    error_message = "Valid value for env is dev, test,sandbox, or prod."
+  }
+}
+
 variable "name" {
   description = "Name for the S3 bucket"
   type        = string

--- a/terraform/services/quicksight/main.tf
+++ b/terraform/services/quicksight/main.tf
@@ -43,11 +43,17 @@ data "aws_region" "current" {}
 module "dpc_insights_data" {
   source = "../../modules/bucket"
   name   = local.dpc_glue_s3_name
+
+  app = var.app
+  env = var.env
 }
 
 module "dpc_insights_athena" {
   source = "../../modules/bucket"
   name   = local.dpc_athena_s3_name
+
+  app = var.app
+  env = var.env
 }
 
 resource "aws_s3_object" "folder" {

--- a/terraform/services/tfstate/main.tf
+++ b/terraform/services/tfstate/main.tf
@@ -5,4 +5,7 @@ locals {
 module "tfstate_bucket" {
   source = "../../modules/bucket"
   name   = local.name
+
+  app = var.app
+  env = var.env
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1282

## 🛠 Changes

bucket module was updated to use our shared kms keys

## ℹ️ Context

The bucket module currently creates  KMS keys for encrypting and decrypting tfstate buckets, the is the need to switch to the shared keys created by the kms-keys service

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

See checks
