### PR TITLE
PLT-1208: Add lifecycle ignore rule to Aurora instance parameter group.

### DIFF
--- a/terraform/modules/aurora/main.tf
+++ b/terraform/modules/aurora/main.tf
@@ -65,6 +65,12 @@ resource "aws_db_parameter_group" "this" {
       value        = parameter.value.value
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      description
+    ]
+  }
 }
 
 resource "aws_rds_cluster" "this" {


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1208

## 🛠 Changes

This PR adds a Terraform lifecycle ignore rule for the Aurora module instance parameter group description.

## ℹ️ Context

The BCDA sandbox and prod instance parameter groups have descriptions that slightly differ from what the Aurora module is expecting. Since the description field on instance parameter groups is immutable, this change is required in order to prevent Terraform from attempting to replace the parameter groups after the pre-existing groups have been imported into the sandbox and prod states.

## 🧪 Validation

This change was validated by importing pre-existing Aurora resources into the sandbox and prod environments and then verifying that subsequent `terraform plan` did not include replacing the parameter groups.
