### PR TITLE
[PLT-1320] Update aws_backup_tag default in Aurora module

### DIFF
--- a/terraform/modules/aurora/variables.tf
+++ b/terraform/modules/aurora/variables.tf
@@ -125,7 +125,7 @@ variable "cluster_identifier" {
 }
 
 variable "aws_backup_tag" {
-  default     = "4hr7_w90"
+  default     = "4Hours1_Daily7_Weekly35_Monthly90"
   description = "Override for a standard, CDAP-managed backup tag for AWS Backups"
   type        = string
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1320

## 🛠 Changes

The default value for the aws_backup_tag in the Aurora module was updated to the current version.

## ℹ️ Context

The aws_backup_tag changed and required an update in the Aurora module.

## 🧪 Validation

This is a trivial default value update.
