### PR TITLE
PLT-1328: Use target_key_arn for cluster storage

### DIFF
--- a/terraform/modules/cluster/main.tf
+++ b/terraform/modules/cluster/main.tf
@@ -8,8 +8,8 @@ resource "aws_ecs_cluster" "this" {
 
   configuration {
     managed_storage_configuration {
-      fargate_ephemeral_storage_kms_key_id = var.platform.kms_alias_primary.target_key_id
-      kms_key_id                           = var.platform.kms_alias_primary.target_key_id
+      fargate_ephemeral_storage_kms_key_id = var.platform.kms_alias_primary.target_key_arn
+      kms_key_id                           = var.platform.kms_alias_primary.target_key_arn
     }
   }
 }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1328

## 🛠 Changes
This prefers the `target_key_arn` over the `target_key_id` in the cluster module's storage configuration. Without this, usage of this module produces unnecessary/meaningless diffs on every apply.

## ℹ️ Context
Post-greenfield migration tasks and standardization for ECS and Fargate.

## 🧪 Validation
As implemented, this was successfully applied against AB2D's `dev` infrastructure and **will** successfully apply to similar environments.