### PR TITLE
[PLT-1345] Updating noncurrent_days value to in bucket module.

### DIFF
--- a/terraform/modules/bucket/main.tf
+++ b/terraform/modules/bucket/main.tf
@@ -130,7 +130,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
     }
 
     noncurrent_version_transition {
-      noncurrent_days = 3
+      noncurrent_days = 30
       storage_class   = "STANDARD_IA"
     }
   }


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1345

## 🛠 Changes

This PR updates the noncurrent_days value from 3 to 30 in the bucket module.

## ℹ️ Context

While applying the aws_s3_bucket_lifecycle_configuration update (introduced in BCDA-9400) the following AWS error was encountered:

```
operation error S3: PutBucketLifecycleConfiguration, https response error StatusCode: 400, RequestID: XXXXXXXXXXXXXXXXXX, HostID:
│ CkeN/<token>, api error InvalidArgument: 'NoncurrentDays' in
│ NoncurrentVersionTransition action must be greater than or equal to 30 for storageClass 'STANDARD_IA'
```
This PR resolves that error.

## 🧪 Validation

The aws_s3_bucket_lifecycle_configuration resource was successfully created in the non-prod account.
