### PR TITLE
[PLT-1332] Adding cron trigger to service workflows.

### DIFF
--- a/.github/workflows/tf-admin-aco-deny.yml
+++ b/.github/workflows/tf-admin-aco-deny.yml
@@ -13,7 +13,7 @@ on:
       - terraform/modules/vpc/**
       # - terraform/services/admin-aco-deny/**
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "*/5 * * * *"
   workflow_dispatch:
     inputs:
       apply:

--- a/.github/workflows/tf-admin-aco-deny.yml
+++ b/.github/workflows/tf-admin-aco-deny.yml
@@ -1,4 +1,4 @@
-name: tf-admin-aco-deny
+name: tf-admin-aco-deny-plt-1332
 run-name: tf-admin-aco-deny ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
 
 on:

--- a/.github/workflows/tf-admin-aco-deny.yml
+++ b/.github/workflows/tf-admin-aco-deny.yml
@@ -4,14 +4,14 @@ run-name: tf-admin-aco-deny ${{ (inputs.apply || (github.event_name == 'push' &&
 on:
   push:
     paths:
-      # - .github/workflows/tf-admin-aco-deny.yml
-      # - terraform/modules/bucket/**
-      # - terraform/modules/key/**
-      # - terraform/modules/function/**
-      # - terraform/modules/queue/**
-      # - terraform/modules/subnets/**
+      - .github/workflows/tf-admin-aco-deny.yml
+      - terraform/modules/bucket/**
+      - terraform/modules/key/**
+      - terraform/modules/function/**
+      - terraform/modules/queue/**
+      - terraform/modules/subnets/**
       - terraform/modules/vpc/**
-      # - terraform/services/admin-aco-deny/**
+      - terraform/services/admin-aco-deny/**
   schedule:
     - cron: "*/5 * * * *"
   workflow_dispatch:
@@ -60,5 +60,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/jscott/PLT-1332')
+      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-admin-aco-deny.yml
+++ b/.github/workflows/tf-admin-aco-deny.yml
@@ -1,4 +1,4 @@
-name: tf-admin-aco-deny-plt-1332
+name: tf-admin-aco-deny
 run-name: tf-admin-aco-deny ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
 
 on:
@@ -13,7 +13,7 @@ on:
       - terraform/modules/vpc/**
       - terraform/services/admin-aco-deny/**
   schedule:
-    - cron: "*/5 * * * *"
+    - cron: "12 14 * * 1-5"
   workflow_dispatch:
     inputs:
       apply:

--- a/.github/workflows/tf-admin-aco-deny.yml
+++ b/.github/workflows/tf-admin-aco-deny.yml
@@ -1,5 +1,5 @@
 name: tf-admin-aco-deny
-run-name: tf-admin-aco-deny ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
+run-name: tf-admin-aco-deny ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule') && 'apply' || 'plan' }}
 
 on:
   push:
@@ -60,5 +60,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
+      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule'
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-admin-aco-deny.yml
+++ b/.github/workflows/tf-admin-aco-deny.yml
@@ -12,6 +12,8 @@ on:
       - terraform/modules/subnets/**
       - terraform/modules/vpc/**
       - terraform/services/admin-aco-deny/**
+  schedule:
+    - cron: "12 14 * * 1-5"
   workflow_dispatch:
     inputs:
       apply:

--- a/.github/workflows/tf-admin-aco-deny.yml
+++ b/.github/workflows/tf-admin-aco-deny.yml
@@ -4,16 +4,16 @@ run-name: tf-admin-aco-deny ${{ (inputs.apply || (github.event_name == 'push' &&
 on:
   push:
     paths:
-      - .github/workflows/tf-admin-aco-deny.yml
-      - terraform/modules/bucket/**
-      - terraform/modules/key/**
-      - terraform/modules/function/**
-      - terraform/modules/queue/**
-      - terraform/modules/subnets/**
+      # - .github/workflows/tf-admin-aco-deny.yml
+      # - terraform/modules/bucket/**
+      # - terraform/modules/key/**
+      # - terraform/modules/function/**
+      # - terraform/modules/queue/**
+      # - terraform/modules/subnets/**
       - terraform/modules/vpc/**
-      - terraform/services/admin-aco-deny/**
+      # - terraform/services/admin-aco-deny/**
   schedule:
-    - cron: "12 14 * * 1-5"
+    - cron: "*/30 * * * *"
   workflow_dispatch:
     inputs:
       apply:
@@ -60,5 +60,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/jscott/PLT-1332')
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-admin-create-aco-creds.yml
+++ b/.github/workflows/tf-admin-create-aco-creds.yml
@@ -60,5 +60,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-admin-create-aco-creds.yml
+++ b/.github/workflows/tf-admin-create-aco-creds.yml
@@ -1,5 +1,5 @@
 name: tf-admin-create-aco-creds
-run-name: tf-admin-create-aco-creds ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
+run-name: tf-admin-create-aco-creds ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule') && 'apply' || 'plan' }}
 
 on:
   push:
@@ -60,5 +60,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
+      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule'
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-admin-create-aco-creds.yml
+++ b/.github/workflows/tf-admin-create-aco-creds.yml
@@ -12,6 +12,8 @@ on:
       - terraform/modules/subnets/**
       - terraform/modules/vpc/**
       - terraform/services/admin-create-aco-creds/**
+  schedule:
+    - cron: "12 14 * * 1-5"
   workflow_dispatch:
     inputs:
       apply:

--- a/.github/workflows/tf-admin-create-aco.yml
+++ b/.github/workflows/tf-admin-create-aco.yml
@@ -60,5 +60,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-admin-create-aco.yml
+++ b/.github/workflows/tf-admin-create-aco.yml
@@ -12,6 +12,8 @@ on:
       - terraform/modules/subnets/**
       - terraform/modules/vpc/**
       - terraform/services/admin-create-aco/**
+  schedule:
+    - cron: "12 14 * * 1-5"
   workflow_dispatch:
     inputs:
       apply:

--- a/.github/workflows/tf-admin-create-aco.yml
+++ b/.github/workflows/tf-admin-create-aco.yml
@@ -1,5 +1,5 @@
 name: tf-admin-create-aco
-run-name: tf-admin-create-aco ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
+run-name: tf-admin-create-aco ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule') && 'apply' || 'plan' }}
 
 on:
   push:
@@ -60,5 +60,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
+      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule'
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-admin-create-group.yml
+++ b/.github/workflows/tf-admin-create-group.yml
@@ -60,5 +60,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-admin-create-group.yml
+++ b/.github/workflows/tf-admin-create-group.yml
@@ -1,5 +1,5 @@
 name: tf-admin-create-group
-run-name: tf-admin-create-group ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
+run-name: tf-admin-create-group ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule') && 'apply' || 'plan' }}
 
 on:
   push:
@@ -60,5 +60,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
+      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule'
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-admin-create-group.yml
+++ b/.github/workflows/tf-admin-create-group.yml
@@ -12,6 +12,8 @@ on:
       - terraform/modules/subnets/**
       - terraform/modules/vpc/**
       - terraform/services/admin-create-group/**
+  schedule:
+    - cron: "12 14 * * 1-5"
   workflow_dispatch:
     inputs:
       apply:

--- a/.github/workflows/tf-alarm-to-slack.yml
+++ b/.github/workflows/tf-alarm-to-slack.yml
@@ -1,5 +1,5 @@
 name: tf-alarm-to-slack
-run-name: tf-alarm-to-slack ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
+run-name: tf-alarm-to-slack ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule') && 'apply' || 'plan' }}
 
 on:
   push:
@@ -74,7 +74,7 @@ jobs:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
           TF_VAR_legacy: "false"
-      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
+      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule'
         run: |
           tofu apply -auto-approve tf.plan
           BUCKET_NAME=$(tofu output -raw zip_bucket_id)

--- a/.github/workflows/tf-alarm-to-slack.yml
+++ b/.github/workflows/tf-alarm-to-slack.yml
@@ -12,6 +12,8 @@ on:
       - terraform/modules/subnets/**
       - terraform/modules/vpc/**
       - terraform/services/alarm-to-slack/**
+  schedule:
+    - cron: "12 14 * * 1-5"
   workflow_dispatch:
     inputs:
       apply:

--- a/.github/workflows/tf-alarm-to-slack.yml
+++ b/.github/workflows/tf-alarm-to-slack.yml
@@ -74,7 +74,7 @@ jobs:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
           TF_VAR_legacy: "false"
-      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
         run: |
           tofu apply -auto-approve tf.plan
           BUCKET_NAME=$(tofu output -raw zip_bucket_id)

--- a/.github/workflows/tf-api-waf-sync.yml
+++ b/.github/workflows/tf-api-waf-sync.yml
@@ -12,6 +12,8 @@ on:
       - terraform/modules/subnets/**
       - terraform/modules/vpc/**
       - terraform/services/api-waf-sync/**
+  schedule:
+    - cron: "12 14 * * 1-5"
   workflow_dispatch:
     inputs:
       apply:

--- a/.github/workflows/tf-api-waf-sync.yml
+++ b/.github/workflows/tf-api-waf-sync.yml
@@ -1,5 +1,5 @@
 name: tf-api-waf-sync
-run-name: tf-api-waf-sync ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
+run-name: tf-api-waf-sync ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule') && 'apply' || 'plan' }}
 
 on:
   push:
@@ -63,7 +63,7 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
+      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule'
         run: |
           tofu apply -auto-approve tf.plan
           BUCKET_NAME=$(tofu output -raw zip_bucket_id)

--- a/.github/workflows/tf-api-waf-sync.yml
+++ b/.github/workflows/tf-api-waf-sync.yml
@@ -63,7 +63,7 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
         run: |
           tofu apply -auto-approve tf.plan
           BUCKET_NAME=$(tofu output -raw zip_bucket_id)

--- a/.github/workflows/tf-api-waf.yml
+++ b/.github/workflows/tf-api-waf.yml
@@ -7,6 +7,8 @@ on:
       - .github/workflows/tf-api-waf.yml
       - terraform/modules/firewall/**
       - terraform/services/api-waf/**
+  schedule:
+    - cron: "12 14 * * 1-5"
   workflow_dispatch:
     inputs:
       apply:

--- a/.github/workflows/tf-api-waf.yml
+++ b/.github/workflows/tf-api-waf.yml
@@ -1,5 +1,5 @@
 name: tf-api-waf
-run-name: tf-api-waf ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
+run-name: tf-api-waf ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule') && 'apply' || 'plan' }}
 
 on:
   push:
@@ -55,5 +55,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
+      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule'
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-api-waf.yml
+++ b/.github/workflows/tf-api-waf.yml
@@ -55,5 +55,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-backup-plan.yml
+++ b/.github/workflows/tf-backup-plan.yml
@@ -1,5 +1,5 @@
 name: tf-backup-plan
-run-name: tf-backup-plan ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
+run-name: tf-backup-plan ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule') && 'apply' || 'plan' }}
 
 on:
   push:
@@ -55,5 +55,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
+      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule'
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-backup-plan.yml
+++ b/.github/workflows/tf-backup-plan.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - .github/workflows/tf-backup-plan.yml
       - terraform/services/backup-plan/**
+  schedule:
+    - cron: "12 14 * * 1-5"
   workflow_dispatch:
     inputs:
       apply:

--- a/.github/workflows/tf-backup-plan.yml
+++ b/.github/workflows/tf-backup-plan.yml
@@ -55,5 +55,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-bucket-access-logs.yml
+++ b/.github/workflows/tf-bucket-access-logs.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - .github/workflows/tf-bucket-access-logs.yml
       - terraform/services/bucket-access-logs/**
+  schedule:
+    - cron: "12 14 * * 1-5"
   workflow_dispatch:
     inputs:
       apply:

--- a/.github/workflows/tf-bucket-access-logs.yml
+++ b/.github/workflows/tf-bucket-access-logs.yml
@@ -1,5 +1,5 @@
 name: tf-bucket-access-logs
-run-name: tf-bucket-access-logs ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
+run-name: tf-bucket-access-logs ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule') && 'apply' || 'plan' }}
 
 on:
   push:
@@ -51,5 +51,5 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - run: tofu init -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
       - run: tofu plan -out=tf.plan
-      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
+      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule'
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-bucket-access-logs.yml
+++ b/.github/workflows/tf-bucket-access-logs.yml
@@ -51,5 +51,5 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - run: tofu init -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
       - run: tofu plan -out=tf.plan
-      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-cclf-import.yml
+++ b/.github/workflows/tf-cclf-import.yml
@@ -60,5 +60,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-cclf-import.yml
+++ b/.github/workflows/tf-cclf-import.yml
@@ -12,6 +12,8 @@ on:
       - terraform/modules/subnets/**
       - terraform/modules/vpc/**
       - terraform/services/cclf-import/**
+  schedule:
+    - cron: "12 14 * * 1-5"
   workflow_dispatch:
     inputs:
       apply:

--- a/.github/workflows/tf-cclf-import.yml
+++ b/.github/workflows/tf-cclf-import.yml
@@ -1,5 +1,5 @@
 name: tf-cclf-import
-run-name: tf-cclf-import ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
+run-name: tf-cclf-import ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule') && 'apply' || 'plan' }}
 
 on:
   push:
@@ -60,5 +60,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
+      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule'
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-external-services-ip-sets.yml
+++ b/.github/workflows/tf-external-services-ip-sets.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - .github/workflows/tf-external-services-ip-sets.yml
       - terraform/services/external-services-ip-sets/**
+  schedule:
+    - cron: "12 14 * * 1-5"
   workflow_dispatch:
     inputs:
       apply:

--- a/.github/workflows/tf-external-services-ip-sets.yml
+++ b/.github/workflows/tf-external-services-ip-sets.yml
@@ -1,5 +1,5 @@
 name: tf-external-services-ip-sets
-run-name: tf-external-services-ip-sets ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
+run-name: tf-external-services-ip-sets ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule') && 'apply' || 'plan' }}
 
 on:
   push:
@@ -51,5 +51,5 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - run: tofu init -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
       - run: tofu plan -out=tf.plan
-      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
+      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule'
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-external-services-ip-sets.yml
+++ b/.github/workflows/tf-external-services-ip-sets.yml
@@ -51,5 +51,5 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - run: tofu init -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
       - run: tofu plan -out=tf.plan
-      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-github-actions-oidc-provider.yml
+++ b/.github/workflows/tf-github-actions-oidc-provider.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - .github/workflows/tf-github-actions-oidc-provider.yml
       - terraform/services/github-actions-oidc-provider/**
+  schedule:
+    - cron: "12 14 * * 1-5"
   workflow_dispatch:
     inputs:
       apply:

--- a/.github/workflows/tf-github-actions-oidc-provider.yml
+++ b/.github/workflows/tf-github-actions-oidc-provider.yml
@@ -52,5 +52,5 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - run: tofu init -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
       - run: tofu plan -out=tf.plan
-      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-github-actions-oidc-provider.yml
+++ b/.github/workflows/tf-github-actions-oidc-provider.yml
@@ -1,5 +1,5 @@
 name: tf-github-actions-oidc-provider
-run-name: tf-github-actions-oidc-provider ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
+run-name: tf-github-actions-oidc-provider ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule') && 'apply' || 'plan' }}
 
 on:
   push:
@@ -52,5 +52,5 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - run: tofu init -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
       - run: tofu plan -out=tf.plan
-      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
+      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule'
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-github-actions-role.yml
+++ b/.github/workflows/tf-github-actions-role.yml
@@ -57,5 +57,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-github-actions-role.yml
+++ b/.github/workflows/tf-github-actions-role.yml
@@ -1,5 +1,5 @@
 name: tf-github-actions-role
-run-name: tf-github-actions-role ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
+run-name: tf-github-actions-role ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule') && 'apply' || 'plan' }}
 
 on:
   push:
@@ -57,5 +57,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
+      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule'
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-github-actions-role.yml
+++ b/.github/workflows/tf-github-actions-role.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - .github/workflows/tf-github-actions-role.yml
       - terraform/services/github-actions-role/**
+  schedule:
+    - cron: "12 14 * * 1-5"
   workflow_dispatch:
     inputs:
       apply:

--- a/.github/workflows/tf-kms-keys.yml
+++ b/.github/workflows/tf-kms-keys.yml
@@ -1,5 +1,5 @@
 name: tf-kms-keys
-run-name: tf-kms-keys ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
+run-name: tf-kms-keys ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule') && 'apply' || 'plan' }}
 
 on:
   push:
@@ -58,5 +58,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
+      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule'
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-kms-keys.yml
+++ b/.github/workflows/tf-kms-keys.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - .github/workflows/tf-kms-keys.yml
       - terraform/services/kms-keys/**
+  schedule:
+    - cron: "12 14 * * 1-5"
   workflow_dispatch:
     inputs:
       apply:

--- a/.github/workflows/tf-kms-keys.yml
+++ b/.github/workflows/tf-kms-keys.yml
@@ -58,5 +58,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-opt-out-export.yml
+++ b/.github/workflows/tf-opt-out-export.yml
@@ -1,5 +1,5 @@
 name: tf-opt-out-export
-run-name: tf-opt-out-export ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
+run-name: tf-opt-out-export ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule') && 'apply' || 'plan' }}
 
 on:
   push:
@@ -63,7 +63,7 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
+      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule'
         run: |
           tofu apply -auto-approve tf.plan
           BUCKET_NAME=$(tofu output -raw zip_bucket_id)

--- a/.github/workflows/tf-opt-out-export.yml
+++ b/.github/workflows/tf-opt-out-export.yml
@@ -12,6 +12,8 @@ on:
       - terraform/modules/subnets/**
       - terraform/modules/vpc/**
       - terraform/services/opt-out-export/**
+  schedule:
+    - cron: "12 14 * * 1-5"
   workflow_dispatch:
     inputs:
       apply:

--- a/.github/workflows/tf-opt-out-export.yml
+++ b/.github/workflows/tf-opt-out-export.yml
@@ -63,7 +63,7 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
         run: |
           tofu apply -auto-approve tf.plan
           BUCKET_NAME=$(tofu output -raw zip_bucket_id)

--- a/.github/workflows/tf-opt-out-import.yml
+++ b/.github/workflows/tf-opt-out-import.yml
@@ -63,5 +63,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-opt-out-import.yml
+++ b/.github/workflows/tf-opt-out-import.yml
@@ -12,6 +12,8 @@ on:
       - terraform/modules/subnets/**
       - terraform/modules/vpc/**
       - terraform/services/opt-out-import/**
+  schedule:
+    - cron: "12 14 * * 1-5"
   workflow_dispatch:
     inputs:
       apply:

--- a/.github/workflows/tf-opt-out-import.yml
+++ b/.github/workflows/tf-opt-out-import.yml
@@ -1,5 +1,5 @@
 name: tf-opt-out-import
-run-name: tf-opt-out-import ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
+run-name: tf-opt-out-import ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule') && 'apply' || 'plan' }}
 
 on:
   push:
@@ -63,5 +63,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
+      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule'
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-security-groups.yml
+++ b/.github/workflows/tf-security-groups.yml
@@ -1,5 +1,5 @@
 name: tf-security-groups
-run-name: tf-security-groups ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
+run-name: tf-security-groups ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule') && 'apply' || 'plan' }}
 
 on:
   push:
@@ -58,5 +58,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
+      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule'
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-security-groups.yml
+++ b/.github/workflows/tf-security-groups.yml
@@ -58,5 +58,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-security-groups.yml
+++ b/.github/workflows/tf-security-groups.yml
@@ -7,6 +7,8 @@ on:
       - .github/workflows/tf-security-groups.yml
       - terraform/modules/vpc/**
       - terraform/services/security-groups/**
+  schedule:
+    - cron: "12 14 * * 1-5"
   workflow_dispatch:
     inputs:
       apply:

--- a/.github/workflows/tf-snyk-integration.yml
+++ b/.github/workflows/tf-snyk-integration.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - .github/workflows/tf-snyk-integration-integration.yml
       - terraform/services/snyk-integration/**
+  schedule:
+    - cron: "12 14 * * 1-5"
   workflow_dispatch:
     inputs:
       apply:

--- a/.github/workflows/tf-snyk-integration.yml
+++ b/.github/workflows/tf-snyk-integration.yml
@@ -52,5 +52,5 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - run: tofu init -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
       - run: tofu plan -out=tf.plan
-      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-snyk-integration.yml
+++ b/.github/workflows/tf-snyk-integration.yml
@@ -1,5 +1,5 @@
 name: tf-snyk-integration
-run-name: tf-snyk-integration ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
+run-name: tf-snyk-integration ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule') && 'apply' || 'plan' }}
 
 on:
   push:
@@ -52,5 +52,5 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
       - run: tofu init -backend-config=../../backends/${{ matrix.app }}-${{ matrix.env }}.s3.tfbackend
       - run: tofu plan -out=tf.plan
-      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
+      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule'
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-tfstate.yml
+++ b/.github/workflows/tf-tfstate.yml
@@ -60,5 +60,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-tfstate.yml
+++ b/.github/workflows/tf-tfstate.yml
@@ -1,5 +1,5 @@
 name: tf-tfstate
-run-name: tf-tfstate ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main')) && 'apply' || 'plan' }}
+run-name: tf-tfstate ${{ (inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule') && 'apply' || 'plan' }}
 
 on:
   push:
@@ -60,5 +60,5 @@ jobs:
         env:
           TF_VAR_app: ${{ matrix.app }}
           TF_VAR_env: ${{ matrix.env }}
-      - if: inputs.apply || ((github.event_name == 'push' || github.event_name == 'schedule') && github.ref == 'refs/heads/main')
+      - if: inputs.apply || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule'
         run: tofu apply -auto-approve tf.plan

--- a/.github/workflows/tf-tfstate.yml
+++ b/.github/workflows/tf-tfstate.yml
@@ -8,6 +8,8 @@ on:
       - terraform/modules/bucket/**
       - terraform/modules/key/**
       - terraform/services/tfstate/**
+  schedule:
+    - cron: "12 14 * * 1-5"
   workflow_dispatch:
     inputs:
       apply:


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1332

## 🛠 Changes

This PR adds a cron trigger of '12 14 * * 1-5' to all TF service workflows to ensure that they are run at 9:12am or 10:12am (depending on daylight savings) every weekday.

## ℹ️ Context

This change is being made to ensure that Terraform drift in any CDAP service will be caught and corrected within one business day.

## 🧪 Validation

When these changes were pushed to a remote branch the 'on push' trigger ran all affected workflows successfully. While this did not exercise the cron triggers directly, it shows that the workflows remain syntactically correct with the addition of the cron triggers.
