### PR TITLE
PLT-1342: Set default force_ssl cluster parameter in aurora module

### DIFF
--- a/terraform/modules/aurora/main.tf
+++ b/terraform/modules/aurora/main.tf
@@ -40,6 +40,12 @@ resource "aws_rds_cluster_parameter_group" "this" {
   family      = local.aurora_family
   description = "Aurora cluster parameter group for ${local.service_prefix}"
 
+  parameter {
+    apply_method = "immediate"
+    name         = "rds.force_ssl"
+    value        = "1"
+  }
+
   dynamic "parameter" {
     for_each = toset(var.cluster_parameters)
 


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/PLT-1342

## 🛠 Changes

default force_ssl cluster parameter has been added in aurora module

## ℹ️ Context

need to standardize default force_ssl cluster parameter across all apis, with shared aurora module in place. its best to have this in module and api teams consume module rather than have it set in apis infra directly.

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

The Terraform plan for the Aurora module changes has been validated in [BCDA-OPS PR #1268](https://github.com/CMSgov/bcda-ops/pull/1268).
