### PR TITLE
BCDA-9395: use full service name for execution role

### DIFF
--- a/terraform/modules/service/main.tf
+++ b/terraform/modules/service/main.tf
@@ -117,7 +117,7 @@ data "aws_iam_policy_document" "execution" {
 
 resource "aws_iam_role" "execution" {
   count = var.execution_role_arn != null ? 0 : 1
-  name  = "${local.service_name}-execution"
+  name  = "${local.service_name_full}-execution"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [


### PR DESCRIPTION
## 🎫 Ticket

https://jira.cms.gov/browse/BCDA-9395

## 🛠 Changes

Updated the name of the ecs service execution role to include the full service name (including app and env) to avoid name clashes between different apps and envs.

## ℹ️ Context

<!-- Why were these changes made? Add background context suitable for a non-technical audience. -->

<!-- If any of the following security implications apply, this PR must not be merged without Stephen Walter's approval. Explain in this section and add @SJWalter11 as a reviewer.
  - Adds a new software dependency or dependencies.
  - Modifies or invalidates one or more of our security controls.
  - Stores or transmits data that was not stored or transmitted before.
  - Requires additional review of security implications for other reasons. -->

## 🧪 Validation

<!-- How were the changes verified? Did you fully test the acceptance criteria in the ticket? Provide reproducible testing instructions and screenshots if applicable. -->
